### PR TITLE
Adding a link to GettingStarted

### DIFF
--- a/documentation/modules/_raml1_artifacts_raml10parser_.html
+++ b/documentation/modules/_raml1_artifacts_raml10parser_.html
@@ -71,6 +71,7 @@
 				<div class="tsd-comment tsd-typography">
 					<p>See <a href="http://raml.org">http://raml.org</a> for more information about RAML.</p>
 					<p>This parser is at a beta state of development, as part of the API Workbench development cycle (<a href="http://apiworkbench.com">http://apiworkbench.com</a>).</p>
+                    <p><a href="https://github.com/raml-org/raml-js-parser-2/blob/master/documentation/GettingStarted.md">Getting Started Guide</a> describes the first steps with the parser.</p>
 					<h2>Installation</h2>
 					<pre><code>git clone https://github.com/raml-org/raml-js-parser-2
 


### PR DESCRIPTION
I am adding it manually for now, as we need to somehow point users to
it when publishing to gh-pages. Later we will need to convert MD to
html and integrate it into documentation building script, I’ll create a
ticket for that.

The link is pointing to master of parser repo instead of a local copy
of MD file as the users, which cloned the repo, should also be able to
see it and might have no MD previewer installed.