### PR TITLE
Traits and resource types expander fix

### DIFF
--- a/src/raml1/ast.core/LowLevelASTProxy.ts
+++ b/src/raml1/ast.core/LowLevelASTProxy.ts
@@ -297,6 +297,9 @@ export class LowLevelCompositeNode extends LowLevelProxyNode{
             var isPrimary = x == this.primaryNode();
             x.originalNode().children().forEach(y=> {
                 var key = y.key();
+                if(x.transformer()){
+                    key = x.transformer().transform(key).value;
+                }
                 if(this.skipKey(key,isPrimary)){
                     return;
                 }

--- a/src/raml1/ast.core/LowLevelASTProxy.ts
+++ b/src/raml1/ast.core/LowLevelASTProxy.ts
@@ -297,7 +297,7 @@ export class LowLevelCompositeNode extends LowLevelProxyNode{
             var isPrimary = x == this.primaryNode();
             x.originalNode().children().forEach(y=> {
                 var key = y.key();
-                if(x.transformer()){
+                if(key && x.transformer()){
                     key = x.transformer().transform(key).value;
                 }
                 if(this.skipKey(key,isPrimary)){

--- a/src/raml1/test/data/expander/expander_test_api16.raml
+++ b/src/raml1/test/data/expander/expander_test_api16.raml
@@ -1,0 +1,32 @@
+#%RAML 1.0
+title: RAML spec
+types:
+  tree_v1_0_0:
+  tree_v1_0_1:
+traits:
+  - responding-xml:
+      responses:
+        200?:
+          description: OK
+          body:
+            application/<<type>>+xml:
+              type: <<type>>
+  - responding-xml2:
+      responses:
+        200?:
+          description: OK
+          body:
+            application/<<type>>+xml:
+              type: <<type>>
+/test:
+  get:
+    is: [
+      responding-xml: {
+        type: tree_v1_0_0,
+      },
+      responding-xml2: {
+        type: tree_v1_0_1,
+      },
+    ]
+    responses:
+      200:

--- a/src/raml1/test/data/expander/expander_test_api16_exp.raml
+++ b/src/raml1/test/data/expander/expander_test_api16_exp.raml
@@ -1,0 +1,38 @@
+#%RAML 1.0
+title: RAML spec
+types:
+  tree_v1_0_0:
+  tree_v1_0_1:
+traits:
+  - responding-xml:
+      responses:
+        200?:
+          description: OK
+          body:
+            application/<<type>>+xml:
+              type: <<type>>
+  - responding-xml2:
+      responses:
+        200?:
+          description: OK
+          body:
+            application/<<type>>+xml:
+              type: <<type>>
+/test:
+  get:
+    is: [
+      responding-xml: {
+        type: tree_v1_0_0,
+      },
+      responding-xml2: {
+        type: tree_v1_0_1,
+      },
+    ]
+    responses:
+      200:
+        description: OK
+        body:
+          application/tree_v1_0_0+xml:
+            type: tree_v1_0_0
+          application/tree_v1_0_1+xml:
+            type: tree_v1_0_1

--- a/src/raml1/test/traits-and-resource-types-expanding-tests.ts
+++ b/src/raml1/test/traits-and-resource-types-expanding-tests.ts
@@ -30,7 +30,7 @@ var expandingTest = function (ind) {
 };
 describe('Traits and resoure types expansion', function () {
     this.timeout(0);
-    for (var i = 16; i <= 16; i++) {
+    for (var i = 0; i <= 16; i++) {
 
         if(i==11||i==12){
             //tests for signatures

--- a/src/raml1/test/traits-and-resource-types-expanding-tests.ts
+++ b/src/raml1/test/traits-and-resource-types-expanding-tests.ts
@@ -30,7 +30,7 @@ var expandingTest = function (ind) {
 };
 describe('Traits and resoure types expansion', function () {
     this.timeout(0);
-    for (var i = 0; i <= 15; i++) {
+    for (var i = 16; i <= 16; i++) {
 
         if(i==11||i==12){
             //tests for signatures


### PR DESCRIPTION
Considering parametrized keys when computing node children.

Partial fix for https://github.com/raml-org/raml-js-parser-2/issues/94