### PR TITLE
Fixing issues 258 and 250

### DIFF
--- a/src/raml1/highLevelImpl.ts
+++ b/src/raml1/highLevelImpl.ts
@@ -831,11 +831,11 @@ export class LowLevelWrapperForTypeSystem extends defs.SourceProvider implements
             return this.children().map(x=>x.value());
         }
         else if (vk===yaml.Kind.MAP||vk===yaml.Kind.ANCHOR_REF){
-            var vl= this._node.dumpToObject(true);
+            var vl= this._node.dumpToObject(false);
             return vl[this.key()];
         }
         else if (this._node.kind()==yaml.Kind.MAP){
-            var vl= this._node.dumpToObject(true);
+            var vl= this._node.dumpToObject(false);
             return vl;
         }
 

--- a/src/raml1/jsyaml/jsyaml2lowLevel.ts
+++ b/src/raml1/jsyaml/jsyaml2lowLevel.ts
@@ -2488,9 +2488,9 @@ export class ASTNode implements lowlevel.ILowLevelASTNode{
                 map.mappings.forEach(x=> {
                     var ms=this.dumpNode(x.value,full);
                     if (ms==null){
-                        ms="!$$$novalue"
+                        ms= full ? "!$$$novalue" : ms;
                     }
-                    if ((ms+"").length>0||full) {
+                    if (ms!=null||full) {
                         res[this.dumpNode(x.key,full) + ""] = ms;
                     }
                 })

--- a/src/raml1/test/data/TCK/RAML10/Examples/test053/lib-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test053/lib-tck.json
@@ -1,0 +1,119 @@
+{
+  "ramlVersion": "RAML10",
+  "type": "Library",
+  "specification": {
+    "types": [
+      {
+        "NullValue": {
+          "name": "NullValue",
+          "displayName": "NullValue",
+          "type": [
+            "object"
+          ],
+          "example": {
+            "name": "Fred"
+          },
+          "repeat": false,
+          "required": true,
+          "properties": {
+            "name": {
+              "name": "name",
+              "displayName": "name",
+              "type": [
+                "string"
+              ],
+              "repeat": false,
+              "required": true,
+              "__METADATA__": {
+                "primitiveValuesMeta": {
+                  "displayName": {
+                    "calculated": true
+                  },
+                  "type": {
+                    "insertedAsDefault": true
+                  },
+                  "repeat": {
+                    "insertedAsDefault": true
+                  },
+                  "required": {
+                    "insertedAsDefault": true
+                  }
+                }
+              }
+            },
+            "comment": {
+              "name": "comment",
+              "displayName": "comment",
+              "type": [
+                "string"
+              ],
+              "repeat": false,
+              "required": true,
+              "__METADATA__": {
+                "primitiveValuesMeta": {
+                  "displayName": {
+                    "calculated": true
+                  },
+                  "type": {
+                    "insertedAsDefault": true
+                  },
+                  "repeat": {
+                    "insertedAsDefault": true
+                  },
+                  "required": {
+                    "insertedAsDefault": true
+                  }
+                }
+              }
+            }
+          },
+          "__METADATA__": {
+            "primitiveValuesMeta": {
+              "displayName": {
+                "calculated": true
+              },
+              "repeat": {
+                "insertedAsDefault": true
+              },
+              "required": {
+                "insertedAsDefault": true
+              }
+            }
+          },
+          "structuredExample": {
+            "value": {
+              "name": "Fred"
+            },
+            "strict": true,
+            "name": null,
+            "structuredValue": {
+              "name": "Fred"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "errors": [
+    {
+      "code": 11,
+      "message": "Required property: comment is missed",
+      "path": "lib.raml",
+      "line": 8,
+      "column": 4,
+      "position": 112,
+      "range": [
+        {
+          "line": 8,
+          "column": 4,
+          "position": 112
+        },
+        {
+          "line": 8,
+          "column": 11,
+          "position": 119
+        }
+      ]
+    }
+  ]
+}

--- a/src/raml1/test/data/TCK/RAML10/Examples/test053/lib-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test053/lib-tck.json
@@ -101,17 +101,17 @@
       "path": "lib.raml",
       "line": 8,
       "column": 4,
-      "position": 112,
+      "position": 104,
       "range": [
         {
           "line": 8,
           "column": 4,
-          "position": 112
+          "position": 104
         },
         {
           "line": 8,
           "column": 11,
-          "position": 119
+          "position": 111
         }
       ]
     }

--- a/src/raml1/test/data/TCK/RAML10/Examples/test053/lib.raml
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test053/lib.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0 Library
+
+types:
+  NullValue:
+    type: object
+    properties:
+      name:
+      comment:
+    example:
+      name: Fred
+      comment:

--- a/src/raml1/test/data/TCK/RAML10/Examples/test054/lib-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test054/lib-tck.json
@@ -1,0 +1,101 @@
+{
+  "ramlVersion": "RAML10",
+  "type": "Library",
+  "specification": {
+    "types": [
+      {
+        "NullValue": {
+          "name": "NullValue",
+          "displayName": "NullValue",
+          "type": [
+            "object"
+          ],
+          "example": {
+            "name": "Fred",
+            "comment": ""
+          },
+          "repeat": false,
+          "required": true,
+          "properties": {
+            "name": {
+              "name": "name",
+              "displayName": "name",
+              "type": [
+                "string"
+              ],
+              "repeat": false,
+              "required": true,
+              "__METADATA__": {
+                "primitiveValuesMeta": {
+                  "displayName": {
+                    "calculated": true
+                  },
+                  "type": {
+                    "insertedAsDefault": true
+                  },
+                  "repeat": {
+                    "insertedAsDefault": true
+                  },
+                  "required": {
+                    "insertedAsDefault": true
+                  }
+                }
+              }
+            },
+            "comment": {
+              "name": "comment",
+              "displayName": "comment",
+              "type": [
+                "string"
+              ],
+              "repeat": false,
+              "required": true,
+              "__METADATA__": {
+                "primitiveValuesMeta": {
+                  "displayName": {
+                    "calculated": true
+                  },
+                  "type": {
+                    "insertedAsDefault": true
+                  },
+                  "repeat": {
+                    "insertedAsDefault": true
+                  },
+                  "required": {
+                    "insertedAsDefault": true
+                  }
+                }
+              }
+            }
+          },
+          "__METADATA__": {
+            "primitiveValuesMeta": {
+              "displayName": {
+                "calculated": true
+              },
+              "repeat": {
+                "insertedAsDefault": true
+              },
+              "required": {
+                "insertedAsDefault": true
+              }
+            }
+          },
+          "structuredExample": {
+            "value": {
+              "name": "Fred",
+              "comment": ""
+            },
+            "strict": true,
+            "name": null,
+            "structuredValue": {
+              "name": "Fred",
+              "comment": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "errors": []
+}

--- a/src/raml1/test/data/TCK/RAML10/Examples/test054/lib.raml
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test054/lib.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0 Library
+
+types:
+  NullValue:
+    type: object
+    properties:
+      name:
+      comment:
+    example:
+      name: Fred
+      comment: ""

--- a/src/raml1/test/data/TCK/RAML10/Examples/test055/lib-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test055/lib-tck.json
@@ -1,0 +1,98 @@
+{
+  "ramlVersion": "RAML10",
+  "type": "Library",
+  "specification": {
+    "types": [
+      {
+        "NullValue": {
+          "name": "NullValue",
+          "displayName": "NullValue",
+          "type": [
+            "object"
+          ],
+          "example": {
+            "name": "Fred",
+            "size": 0
+          },
+          "repeat": false,
+          "required": true,
+          "properties": {
+            "name": {
+              "name": "name",
+              "displayName": "name",
+              "type": [
+                "string"
+              ],
+              "repeat": false,
+              "required": true,
+              "__METADATA__": {
+                "primitiveValuesMeta": {
+                  "displayName": {
+                    "calculated": true
+                  },
+                  "type": {
+                    "insertedAsDefault": true
+                  },
+                  "repeat": {
+                    "insertedAsDefault": true
+                  },
+                  "required": {
+                    "insertedAsDefault": true
+                  }
+                }
+              }
+            },
+            "size": {
+              "name": "size",
+              "displayName": "size",
+              "type": [
+                "number"
+              ],
+              "repeat": false,
+              "required": true,
+              "__METADATA__": {
+                "primitiveValuesMeta": {
+                  "displayName": {
+                    "calculated": true
+                  },
+                  "repeat": {
+                    "insertedAsDefault": true
+                  },
+                  "required": {
+                    "insertedAsDefault": true
+                  }
+                }
+              }
+            }
+          },
+          "__METADATA__": {
+            "primitiveValuesMeta": {
+              "displayName": {
+                "calculated": true
+              },
+              "repeat": {
+                "insertedAsDefault": true
+              },
+              "required": {
+                "insertedAsDefault": true
+              }
+            }
+          },
+          "structuredExample": {
+            "value": {
+              "name": "Fred",
+              "size": 0
+            },
+            "strict": true,
+            "name": null,
+            "structuredValue": {
+              "name": "Fred",
+              "size": 0
+            }
+          }
+        }
+      }
+    ]
+  },
+  "errors": []
+}

--- a/src/raml1/test/data/TCK/RAML10/Examples/test055/lib.raml
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test055/lib.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0 Library
+
+types:
+  NullValue:
+    type: object
+    properties:
+      name:
+      size: number
+    example:
+      name: Fred
+      size: 0

--- a/src/raml1/test/parserTests.ts
+++ b/src/raml1/test/parserTests.ts
@@ -530,7 +530,7 @@ describe('Parser regression tests', function () {
         testErrors(util.data("parser/typexpressions/tr7.raml"),["Required property: element is missed"]);
     })
     it ("inplace types 00" ,function(){
-        testErrors(util.data("parser/typexpressions/tr8.raml"),["object is expected"]);//Ok for now lets improve later
+        testErrors(util.data("parser/typexpressions/tr8.raml"),["Required property: ddd is missed"]);//Ok for now lets improve later
     })
     it ("unique keys" ,function(){
         testErrors(util.data("parser/typexpressions/tr9.raml"),["Keys should be unique"]);//Ok for now lets improve later


### PR DESCRIPTION
Fixed issues:
* https://github.com/raml-org/raml-js-parser-2/issues/258
* https://github.com/raml-org/raml-js-parser-2/issues/250

Getting rid of "!$$$novalue" placeholders for empty values in examples.