### PR TITLE
Fixing ExampleSpec.value() retrun type.

### DIFF
--- a/src/raml1/jsyaml/json2lowLevel.ts
+++ b/src/raml1/jsyaml/json2lowLevel.ts
@@ -270,7 +270,23 @@ export class AstNode implements lowlevel.ILowLevelASTNode{
         }
     }
 
-    valueKind(){ return null;}
+    valueKind(){
+        if(!this._object){
+            return null;
+        }
+
+        var valType = typeof this._object;
+        if(Array.isArray(this._object)){
+            return yaml.Kind.SEQ;
+        }
+        else if(valType == "object"){
+            return yaml.Kind.MAP;
+        }
+        else if(valType == "string"||valType=="number"||valType=="boolean"){
+            return yaml.Kind.SCALAR;
+        }
+        return null;
+    }
 
     show(msg: string){}
 

--- a/src/raml1/test/data/TCK/RAML10/Examples/test001/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test001/api-tck.json
@@ -56,9 +56,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "a": 5
-            },
+            "value": "{\n  \"a\": 5\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -127,6 +125,7 @@
                       }
                     },
                     "structuredExample": {
+                      "value": "{ d\":5 ,\"r\":2 }\n",
                       "strict": true,
                       "name": null
                     }

--- a/src/raml1/test/data/TCK/RAML10/Examples/test002/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test002/api-tck.json
@@ -233,20 +233,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "Brandicted",
-              "logo": "http://www.domain.com/logo.gif",
-              "followers": [
-                {
-                  "firstName": "Fred",
-                  "lastName": "Armand"
-                },
-                {
-                  "firstName": "Joan",
-                  "lastName": "Rivers"
-                }
-              ]
-            },
+            "value": "{\n  \"name\": \"Brandicted\",\n  \"logo\": \"http://www.domain.com/logo.gif\",\n  \"followers\": [\n    {\n      \"firstName\": \"Fred\",\n      \"lastName\": \"Armand\"\n    },\n    {\n      \"firstName\": \"Joan\",\n      \"lastName\": \"Rivers\"\n    }\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test003/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test003/api-tck.json
@@ -234,21 +234,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "Brandicted",
-              "logo": "http://www.domain.com/logo.gif",
-              "followers": [
-                {
-                  "firstName": "Fred",
-                  "lastName": "Armand"
-                },
-                {
-                  "firstName": "Joan",
-                  "lastName": "Rivers"
-                }
-              ],
-              "X": "x"
-            },
+            "value": "{\n  \"name\": \"Brandicted\",\n  \"logo\": \"http://www.domain.com/logo.gif\",\n  \"followers\": [\n    {\n      \"firstName\": \"Fred\",\n      \"lastName\": \"Armand\"\n    },\n    {\n      \"firstName\": \"Joan\",\n      \"lastName\": \"Rivers\"\n    }\n  ],\n  \"X\": \"x\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test004/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test004/api-tck.json
@@ -234,21 +234,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "Brandicted",
-              "logo": "http://www.domain.com/logo.gif",
-              "followers": [
-                {
-                  "firstName": "Fred",
-                  "lastName": "Armand"
-                },
-                {
-                  "firstName": "Joan",
-                  "lastName": "Rivers"
-                }
-              ],
-              "X": "x"
-            },
+            "value": "{\n  \"name\": \"Brandicted\",\n  \"logo\": \"http://www.domain.com/logo.gif\",\n  \"followers\": [\n    {\n      \"firstName\": \"Fred\",\n      \"lastName\": \"Armand\"\n    },\n    {\n      \"firstName\": \"Joan\",\n      \"lastName\": \"Rivers\"\n    }\n  ],\n  \"X\": \"x\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test005/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test005/api-tck.json
@@ -76,10 +76,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "c": "A",
-              "y": 3
-            },
+            "value": "{\n  \"c\": \"A\",\n  \"y\": 3\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test006/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test006/api-tck.json
@@ -80,11 +80,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "x": 1,
-              "y": 3,
-              "z": 5
-            },
+            "value": "{\n  \"x\": 1,\n  \"y\": 3,\n  \"z\": 5\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test007/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test007/api-tck.json
@@ -61,9 +61,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "y": "aaa2"
-            },
+            "value": "{\n  \"y\": \"aaa2\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test008/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test008/api-tck.json
@@ -118,24 +118,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "items": [
-                1,
-                2,
-                3
-              ],
-              "items2": [
-                3,
-                1,
-                4,
-                5
-              ],
-              "items3": [
-                1,
-                2,
-                1
-              ]
-            },
+            "value": "{\n  \"items\": [\n    1,\n    2,\n    3\n  ],\n  \"items2\": [\n    3,\n    1,\n    4,\n    5\n  ],\n  \"items3\": [\n    1,\n    2,\n    1\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test009/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test009/api-tck.json
@@ -117,23 +117,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "items": [
-                1,
-                2,
-                3
-              ],
-              "items2": [
-                3,
-                1,
-                4
-              ],
-              "items3": [
-                1,
-                2,
-                3
-              ]
-            },
+            "value": "{\n  \"items\": [\n    1,\n    2,\n    3\n  ],\n  \"items2\": [\n    3,\n    1,\n    4\n  ],\n  \"items3\": [\n    1,\n    2,\n    3\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test010/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test010/api-tck.json
@@ -85,13 +85,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "items": [
-                "1",
-                "2",
-                "3"
-              ]
-            },
+            "value": "{\n  \"items\": [\n    \"1\",\n    \"2\",\n    \"3\"\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test012/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test012/api-tck.json
@@ -94,10 +94,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "message": "s",
-                        "r": 2
-                      },
+                      "value": "{ \"message\":\"s\" ,\"r\":2 }\n",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test013/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test013/api-tck.json
@@ -56,9 +56,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "d": "a"
-            },
+            "value": "{\n  \"d\": \"a\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test014/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test014/api-tck.json
@@ -58,10 +58,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "d": "a",
-              "dd": "2"
-            },
+            "value": "{\n  \"d\": \"a\",\n  \"dd\": \"2\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -97,9 +94,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "x": "3"
-            },
+            "value": "{\n  \"x\": \"3\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test015/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test015/api-tck.json
@@ -58,10 +58,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "d": "a",
-              "dd": "2"
-            },
+            "value": "{\n  \"d\": \"a\",\n  \"dd\": \"2\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -97,9 +94,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "x": "3"
-            },
+            "value": "{\n  \"x\": \"3\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test020/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test020/api-tck.json
@@ -91,9 +91,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "z": "3"
-            },
+            "value": "{\n  \"z\": \"3\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test021/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test021/api-tck.json
@@ -91,9 +91,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "z": ".3"
-            },
+            "value": "{\n  \"z\": \".3\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test022/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test022/api-tck.json
@@ -28,7 +28,7 @@
             }
           },
           "structuredExample": {
-            "value": 4,
+            "value": "4",
             "strict": true,
             "name": null,
             "structuredValue": 4
@@ -88,9 +88,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "z": 3
-            },
+            "value": "{\n  \"z\": 3\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test023/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test023/api-tck.json
@@ -56,9 +56,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "a": 5
-            },
+            "value": "{\n  \"a\": 5\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -107,10 +105,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "message": 4,
-                        "vlue": 3
-                      },
+                      "value": "{\n  \"message\": 4,\n  \"vlue\": 3\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test024/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test024/api-tck.json
@@ -28,7 +28,7 @@
             }
           },
           "structuredExample": {
-            "value": 5,
+            "value": "5",
             "strict": true,
             "name": null,
             "structuredValue": 5
@@ -88,9 +88,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "z": 5
-            },
+            "value": "{\n  \"z\": 5\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test025/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test025/api-tck.json
@@ -450,42 +450,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "id": "146df5d64e5cb7dc",
-              "historyId": "535370",
-              "messages": [
-                {
-                  "id": "146df5d64e5cb7dc",
-                  "payload": {
-                    "mimeType": "text/plain",
-                    "filename": "",
-                    "headers": [
-                      {
-                        "name": "Received",
-                        "value": "from 833522106252-kj93b6c68h8dq0438mjuasrvm6bsfjvm.apps.googleusercontent.com named unknown by gmailapi.google.com with HTTPREST; Fri, 27 Jun 2014 15:06:18 -0700"
-                      },
-                      {
-                        "name": "Date",
-                        "value": "Fri, 27 Jun 2014 15:06:18 -0700"
-                      },
-                      {
-                        "name": "Message-Id",
-                        "value": "<CAEzS4YC_gro+vJ8aoiccD8emmF=KkBjG12mXOh53+wWsR9YQVQ@mail.gmail.com>"
-                      },
-                      {
-                        "name": "From",
-                        "value": "someaccount@gmail.com"
-                      }
-                    ],
-                    "body": {
-                      "size": 1,
-                      "data": ""
-                    }
-                  },
-                  "sizeEstimate": 331
-                }
-              ]
-            },
+            "value": "{\n  \"id\": \"146df5d64e5cb7dc\",\n  \"historyId\": \"535370\",\n  \"messages\": [\n    {\n      \"id\": \"146df5d64e5cb7dc\",\n      \"payload\": {\n        \"mimeType\": \"text/plain\",\n        \"filename\": \"\",\n        \"headers\": [\n          {\n            \"name\": \"Received\",\n            \"value\": \"from 833522106252-kj93b6c68h8dq0438mjuasrvm6bsfjvm.apps.googleusercontent.com named unknown by gmailapi.google.com with HTTPREST; Fri, 27 Jun 2014 15:06:18 -0700\"\n          },\n          {\n            \"name\": \"Date\",\n            \"value\": \"Fri, 27 Jun 2014 15:06:18 -0700\"\n          },\n          {\n            \"name\": \"Message-Id\",\n            \"value\": \"<CAEzS4YC_gro+vJ8aoiccD8emmF=KkBjG12mXOh53+wWsR9YQVQ@mail.gmail.com>\"\n          },\n          {\n            \"name\": \"From\",\n            \"value\": \"someaccount@gmail.com\"\n          }\n        ],\n        \"body\": {\n          \"size\": 1,\n          \"data\": \"\"\n        }\n      },\n      \"sizeEstimate\": 331\n    }\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test026/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test026/api-tck.json
@@ -425,6 +425,7 @@
                           }
                         },
                         "structuredExample": {
+                          "value": "{\n  \"name\" : \"blah\",\n  \"name2\" : \"blah\",\n  \"name3\" : {\n      proppp: \"123245\"\n  }\n}\n",
                           "strict": true,
                           "name": null
                         }

--- a/src/raml1/test/data/TCK/RAML10/Examples/test027/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test027/api-tck.json
@@ -79,10 +79,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "stringValue",
-              "age": 0
-            },
+            "value": "{\n  \"name\": \"stringValue\",\n  \"age\": 0\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test028/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test028/api-tck.json
@@ -154,9 +154,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": {
-                            "x2": 123
-                          },
+                          "value": "{\n  \"x2\": 123\n}",
                           "strict": true,
                           "name": null,
                           "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test029/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test029/api-tck.json
@@ -702,44 +702,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "type": "aws",
-              "uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:ACCOUNT_ID:function:myFunction/invocations",
-              "httpMethod": "POST",
-              "credentials": "arn:aws:iam::ACCOUNT_ID:role/lambda_exec_role",
-              "requestTemplates": {
-                "application/json": "json request template 2",
-                "application/xml": "xml request template 2"
-              },
-              "requestParameters": {
-                "integration.request.path.integrationPathParam": "method.request.querystring.latitude",
-                "integration.request.querystring.integrationQueryParam": "method.request.querystring.longitude"
-              },
-              "cacheNamespace": "cache namespace",
-              "cacheKeyParameters": [],
-              "responses": {
-                "2\\d{2}": {
-                  "statusCode": "200",
-                  "responseParameters": {
-                    "method.response.header.test-method-response-header": "integration.response.header.integrationResponseHeaderParam1"
-                  },
-                  "responseTemplates": {
-                    "application/json": "json 200 response template",
-                    "application/xml": "xml 200 response template"
-                  }
-                },
-                "default": {
-                  "statusCode": "400",
-                  "responseParameters": {
-                    "method.response.header.test-method-response-header": "'static value'"
-                  },
-                  "responseTemplates": {
-                    "application/json": "json 400 response template",
-                    "application/xml": "xml 400 response template"
-                  }
-                }
-              }
-            },
+            "value": "{\n  \"type\": \"aws\",\n  \"uri\": \"arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:ACCOUNT_ID:function:myFunction/invocations\",\n  \"httpMethod\": \"POST\",\n  \"credentials\": \"arn:aws:iam::ACCOUNT_ID:role/lambda_exec_role\",\n  \"requestTemplates\": {\n    \"application/json\": \"json request template 2\",\n    \"application/xml\": \"xml request template 2\"\n  },\n  \"requestParameters\": {\n    \"integration.request.path.integrationPathParam\": \"method.request.querystring.latitude\",\n    \"integration.request.querystring.integrationQueryParam\": \"method.request.querystring.longitude\"\n  },\n  \"cacheNamespace\": \"cache namespace\",\n  \"cacheKeyParameters\": [],\n  \"responses\": {\n    \"2\\\\d{2}\": {\n      \"statusCode\": \"200\",\n      \"responseParameters\": {\n        \"method.response.header.test-method-response-header\": \"integration.response.header.integrationResponseHeaderParam1\"\n      },\n      \"responseTemplates\": {\n        \"application/json\": \"json 200 response template\",\n        \"application/xml\": \"xml 200 response template\"\n      }\n    },\n    \"default\": {\n      \"statusCode\": \"400\",\n      \"responseParameters\": {\n        \"method.response.header.test-method-response-header\": \"'static value'\"\n      },\n      \"responseTemplates\": {\n        \"application/json\": \"json 400 response template\",\n        \"application/xml\": \"xml 400 response template\"\n      }\n    }\n  }\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test032/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test032/api-tck.json
@@ -117,11 +117,7 @@
                     ],
                     "examples": [
                       {
-                        "value": {
-                          "additionalField": "asd",
-                          "baseField": "asdasd",
-                          "field": "asdds"
-                        },
+                        "value": "{\n  \"additionalField\": \"asd\",\n  \"baseField\": \"asdasd\",\n  \"field\": \"asdds\"\n}",
                         "strict": true,
                         "name": "aaa",
                         "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test033/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test033/api-tck.json
@@ -160,11 +160,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "additionalField": "asd",
-                        "baseField": "asdasd",
-                        "field": "asdds"
-                      },
+                      "value": "{\n  \"additionalField\": \"asd\",\n  \"baseField\": \"asdasd\",\n  \"field\": \"asdds\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test034/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test034/api-tck.json
@@ -187,9 +187,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "a": 3
-                      },
+                      "value": "{\n  \"a\": 3\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test035/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test035/api-tck.json
@@ -59,12 +59,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "prop1": "stringValue1",
-              "prop2": {
-                "someProperty": "stringValue2"
-              }
-            },
+            "value": "{\n  \"prop1\": \"stringValue1\",\n  \"prop2\": {\n    \"someProperty\": \"stringValue2\"\n  }\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test036/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test036/api-tck.json
@@ -56,9 +56,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "prop1": "stringValue"
-            },
+            "value": "{\n  \"prop1\": \"stringValue\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test037/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test037/api-tck.json
@@ -27,7 +27,7 @@
             }
           },
           "structuredExample": {
-            "value": 100,
+            "value": "100",
             "strict": true,
             "name": null,
             "structuredValue": 100
@@ -61,15 +61,13 @@
             }
           },
           "structuredExample": {
-            "value": [
-              100,
-              10
-            ],
+            "value": "[\n  100,\n  10\n]",
             "strict": true,
             "name": null,
-            "structuredValue": {
-              "undefined": 10
-            }
+            "structuredValue": [
+              100,
+              10
+            ]
           }
         }
       },
@@ -97,7 +95,7 @@
             }
           },
           "structuredExample": {
-            "value": true,
+            "value": "true",
             "strict": true,
             "name": null,
             "structuredValue": true

--- a/src/raml1/test/data/TCK/RAML10/Examples/test039/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test039/api-tck.json
@@ -28,7 +28,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": 2,
+                  "value": "2",
                   "strict": true,
                   "name": null,
                   "structuredValue": 2

--- a/src/raml1/test/data/TCK/RAML10/Examples/test040/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test040/api-tck.json
@@ -30,14 +30,12 @@
                   }
                 },
                 "structuredExample": {
-                  "value": [
-                    2
-                  ],
+                  "value": "[\n  2\n]",
                   "strict": true,
                   "name": null,
-                  "structuredValue": {
-                    "undefined": 2
-                  }
+                  "structuredValue": [
+                    2
+                  ]
                 }
               }
             },

--- a/src/raml1/test/data/TCK/RAML10/Examples/test041/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test041/api-tck.json
@@ -213,9 +213,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "a": 3
-                      },
+                      "value": "{\n  \"a\": 3\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test042/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test042/api-tck.json
@@ -272,18 +272,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "a": 3,
-                        "items": [
-                          {
-                            "c": 3
-                          },
-                          {
-                            "b": "4",
-                            "c1": "3"
-                          }
-                        ]
-                      },
+                      "value": "{\n  \"a\": 3,\n  \"items\": [\n    {\n      \"c\": 3\n    },\n    {\n      \"b\": \"4\",\n      \"c1\": \"3\"\n    }\n  ]\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test043/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test043/api-tck.json
@@ -12,18 +12,7 @@
           ],
           "examples": [
             {
-              "value": {
-                "a": 3,
-                "items": [
-                  {
-                    "c": 4,
-                    "r1": 3
-                  },
-                  {
-                    "r2": 3
-                  }
-                ]
-              },
+              "value": "{\n  \"a\": 3,\n  \"items\": [\n    {\n      \"c\": 4,\n      \"r1\": 3\n    },\n    {\n      \"r2\": 3\n    }\n  ]\n}",
               "strict": true,
               "name": "f1",
               "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test044/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test044/api-tck.json
@@ -31,7 +31,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": true,
+                  "value": "true",
                   "strict": true,
                   "name": null,
                   "structuredValue": true

--- a/src/raml1/test/data/TCK/RAML10/Examples/test045/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test045/api-tck.json
@@ -44,14 +44,7 @@
               ],
               "examples": [
                 {
-                  "value": {
-                    "strict": true,
-                    "content": [
-                      {
-                        "X-Dept": "230-OCTO"
-                      }
-                    ]
-                  },
+                  "value": "{\n  \"strict\": true,\n  \"content\": [\n    {\n      \"X-Dept\": \"230-OCTO\"\n    }\n  ]\n}",
                   "strict": true,
                   "name": "one_dept",
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test046/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test046/api-tck.json
@@ -59,9 +59,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "prop1": "value1"
-            },
+            "value": "{\n  \"prop1\": \"value1\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test047/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test047/api-tck.json
@@ -59,9 +59,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "prop1": "value1"
-            },
+            "value": "{\n  \"prop1\": \"value1\"\n}\n",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test048/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test048/api-tck.json
@@ -59,9 +59,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "prop1": "value1"
-            },
+            "value": "{\n  \"prop1\": \"value1\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test049/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test049/api-tck.json
@@ -71,9 +71,7 @@
                 "name": "ObjectAnnotation"
               }
             },
-            "value": {
-              "prop1": "value1"
-            },
+            "value": "{\n  \"prop1\": \"value1\"\n}",
             "strict": false,
             "name": null,
             "displayName": "myExample",

--- a/src/raml1/test/data/TCK/RAML10/Examples/test050/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test050/api-tck.json
@@ -24,9 +24,7 @@
                   "name": "ObjectAnnotation"
                 }
               },
-              "value": {
-                "prop1": "value1"
-              },
+              "value": "{\n  \"prop1\": \"value1\"\n}",
               "strict": false,
               "displayName": "myExample1",
               "description": "example 1 of ObjectType3",
@@ -47,9 +45,7 @@
                   "name": "ObjectAnnotation"
                 }
               },
-              "value": {
-                "prop1": "value2"
-              },
+              "value": "{\n  \"prop1\": \"value2\"\n}",
               "strict": false,
               "displayName": "myExample2",
               "description": "example 2 of ObjectType3",

--- a/src/raml1/test/data/TCK/RAML10/Examples/test051/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test051/api-tck.json
@@ -24,9 +24,7 @@
                   "name": "ObjectAnnotation"
                 }
               },
-              "value": {
-                "prop1": "value1"
-              },
+              "value": "{\n  \"prop1\": \"value1\"\n}",
               "strict": false,
               "name": "example1",
               "displayName": "myExample1",
@@ -48,9 +46,7 @@
                   "name": "ObjectAnnotation"
                 }
               },
-              "value": {
-                "prop1": "value2"
-              },
+              "value": "{\n  \"prop1\": \"value2\"\n}",
               "strict": false,
               "name": "example2",
               "displayName": "myExample2",

--- a/src/raml1/test/data/TCK/RAML10/Examples/test052/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test052/api-tck.json
@@ -77,7 +77,10 @@
                       }
                     },
                     "structuredExample": {
-                      "value": [
+                      "value": "[\n  {\n    \"id\": 1,\n    \"title\": \"feature1\",\n    \"description\": \"description of feature 1\",\n    \"pic\": \"http://naw.netatwork.netdna-cdn.com/uploads/2015/06/icon-security-monitoring.png\"\n  },\n  {\n    \"id\": 2,\n    \"title\": \"feature2\",\n    \"description\": \"description of feature 2\",\n    \"pic\": \"http://naw.netatwork.netdna-cdn.com/uploads/2015/06/icon-security-monitoring.png\"\n  },\n  {\n    \"id\": 3,\n    \"title\": \"feature3\",\n    \"description\": \"description of feature 3\",\n    \"pic\": \"http://naw.netatwork.netdna-cdn.com/uploads/2015/06/icon-security-monitoring.png\"\n  },\n  {\n    \"id\": 4,\n    \"title\": \"feature4\",\n    \"description\": \"description of feature 4\",\n    \"pic\": \"http://naw.netatwork.netdna-cdn.com/uploads/2015/06/icon-security-monitoring.png\"\n  },\n  {\n    \"id\": 5,\n    \"title\": \"feature5\",\n    \"description\": \"description of feature 4\",\n    \"pic\": \"http://naw.netatwork.netdna-cdn.com/uploads/2015/06/icon-security-monitoring.png\"\n  }\n]",
+                      "strict": true,
+                      "name": null,
+                      "structuredValue": [
                         {
                           "id": 1,
                           "title": "feature1",
@@ -108,17 +111,7 @@
                           "description": "description of feature 4",
                           "pic": "http://naw.netatwork.netdna-cdn.com/uploads/2015/06/icon-security-monitoring.png"
                         }
-                      ],
-                      "strict": true,
-                      "name": null,
-                      "structuredValue": {
-                        "undefined": {
-                          "id": 5,
-                          "title": "feature5",
-                          "description": "description of feature 4",
-                          "pic": "http://naw.netatwork.netdna-cdn.com/uploads/2015/06/icon-security-monitoring.png"
-                        }
-                      }
+                      ]
                     }
                   }
                 }

--- a/src/raml1/test/data/TCK/RAML10/Examples/test053/lib-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test053/lib-tck.json
@@ -81,9 +81,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "Fred"
-            },
+            "value": "{\n  \"name\": \"Fred\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test054/lib-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test054/lib-tck.json
@@ -82,10 +82,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "Fred",
-              "comment": ""
-            },
+            "value": "{\n  \"name\": \"Fred\",\n  \"comment\": \"\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test055/lib-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test055/lib-tck.json
@@ -79,10 +79,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "Fred",
-              "size": 0
-            },
+            "value": "{\n  \"name\": \"Fred\",\n  \"size\": 0\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test056/lib-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test056/lib-tck.json
@@ -82,10 +82,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": null,
-              "data": null
-            },
+            "value": "{\n  \"name\": null,\n  \"data\": null\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test057/lib-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test057/lib-tck.json
@@ -79,10 +79,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": null,
-              "data": null
-            },
+            "value": "{\n  \"name\": null,\n  \"data\": null\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test058/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test058/api-tck.json
@@ -204,10 +204,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "name": "Rex",
-                        "fangs": "big ones"
-                      },
+                      "value": "{\n  \"name\": \"Rex\",\n  \"fangs\": \"big ones\"\n}\n",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test059/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test059/api-tck.json
@@ -204,10 +204,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "name": "Rex",
-                        "fangs-INCORRECT": "big ones"
-                      },
+                      "value": "{\n  \"name\": \"Rex\",\n  \"fangs-INCORRECT\": \"big ones\"\n}\n",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test060/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test060/api-tck.json
@@ -31,16 +31,14 @@
             }
           },
           "structuredExample": {
-            "value": [
+            "value": "[ 0.0, 1.0, 2.0 ]\n",
+            "strict": true,
+            "name": null,
+            "structuredValue": [
               0,
               1,
               2
-            ],
-            "strict": true,
-            "name": null,
-            "structuredValue": {
-              "undefined": 2
-            }
+            ]
           }
         }
       },
@@ -101,13 +99,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "p": [
-                1,
-                0,
-                0
-              ]
-            },
+            "value": "{\n  \"p\": [ 1.0, 0.0, 0.0 ]\n}\n",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Examples/test061/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test061/api-tck.json
@@ -84,13 +84,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "p": [
-                1,
-                0,
-                0
-              ]
-            },
+            "value": "{\n  \"p\": [\n    1,\n    0,\n    0\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Instagram1.0/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Instagram1.0/api-tck.json
@@ -176,7 +176,7 @@
                 }
               },
               "structuredExample": {
-                "value": 1,
+                "value": "1",
                 "strict": true,
                 "name": null,
                 "structuredValue": 1
@@ -392,31 +392,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "data": [
-                          {
-                            "username": "jack",
-                            "first_name": "Jack",
-                            "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_66_75sq.jpg",
-                            "id": "66",
-                            "last_name": "Dorsey"
-                          },
-                          {
-                            "username": "sammyjack",
-                            "first_name": "Sammy",
-                            "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_29648_75sq_1294520029.jpg",
-                            "id": "29648",
-                            "last_name": "Jack"
-                          },
-                          {
-                            "username": "jacktiddy",
-                            "first_name": "Jack",
-                            "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_13096_75sq_1286441317.jpg",
-                            "id": "13096",
-                            "last_name": "Tiddy"
-                          }
-                        ]
-                      },
+                      "value": "{\n    \"data\": [{\n        \"username\": \"jack\",\n        \"first_name\": \"Jack\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_66_75sq.jpg\",\n        \"id\": \"66\",\n        \"last_name\": \"Dorsey\"\n    },\n    {\n        \"username\": \"sammyjack\",\n        \"first_name\": \"Sammy\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_29648_75sq_1294520029.jpg\",\n        \"id\": \"29648\",\n        \"last_name\": \"Jack\"\n    },\n    {\n        \"username\": \"jacktiddy\",\n        \"first_name\": \"Jack\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_13096_75sq_1286441317.jpg\",\n        \"id\": \"13096\",\n        \"last_name\": \"Tiddy\"\n    }]\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {
@@ -605,100 +581,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "data": {
-                          "distance": 50,
-                          "type": "image",
-                          "users_in_photo": [
-                            {
-                              "user": {
-                                "username": "kevin",
-                                "full_name": "Kevin S",
-                                "id": "3",
-                                "profile_picture": "..."
-                              },
-                              "position": {
-                                "x": 0.315,
-                                "y": 0.9111
-                              }
-                            }
-                          ],
-                          "filter": "Walden",
-                          "tags": [],
-                          "comments": {
-                            "data": [
-                              {
-                                "created_time": "1279332030",
-                                "text": "Love the sign here",
-                                "from": {
-                                  "username": "mikeyk",
-                                  "full_name": "Mikey Krieger",
-                                  "id": "4",
-                                  "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg"
-                                },
-                                "id": "8"
-                              }
-                            ],
-                            "count": 2
-                          },
-                          "caption": {
-                            "created_time": "1296710352",
-                            "text": "Inside le truc #foodtruck",
-                            "from": {
-                              "username": "kevin",
-                              "full_name": "Kevin Systrom",
-                              "type": "user",
-                              "id": "3"
-                            },
-                            "id": "26621408"
-                          },
-                          "likes": {
-                            "count": 1,
-                            "data": [
-                              {
-                                "username": "mikeyk",
-                                "full_name": "Mikeyk",
-                                "id": "4",
-                                "profile_picture": "..."
-                              }
-                            ]
-                          },
-                          "link": "http://instagr.am/p/D/",
-                          "user": {
-                            "username": "kevin",
-                            "full_name": "Kevin S",
-                            "profile_picture": "...",
-                            "bio": "...",
-                            "website": "...",
-                            "id": "3"
-                          },
-                          "created_time": "1279340983",
-                          "images": {
-                            "low_resolution": {
-                              "url": "http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_6.jpg",
-                              "width": 306,
-                              "height": 306
-                            },
-                            "thumbnail": {
-                              "url": "http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_5.jpg",
-                              "width": 150,
-                              "height": 150
-                            },
-                            "standard_resolution": {
-                              "url": "http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_7.jpg",
-                              "width": 612,
-                              "height": 612
-                            }
-                          },
-                          "id": "3",
-                          "location": {
-                            "id": "id",
-                            "latitude": -34,
-                            "longitude": -53,
-                            "name": "some place"
-                          }
-                        }
-                      },
+                      "value": "{\n    \"data\": {\n        \"distance\" : 50,\n        \"type\": \"image\",\n        \"users_in_photo\": [{\n            \"user\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin S\",\n                \"id\": \"3\",\n                \"profile_picture\": \"...\"\n            },\n            \"position\": {\n                \"x\": 0.315,\n                \"y\": 0.9111\n            }\n        }],\n        \"filter\": \"Walden\",\n        \"tags\": [],\n        \"comments\": {\n            \"data\": [{\n                \"created_time\": \"1279332030\",\n                \"text\": \"Love the sign here\",\n                \"from\": {\n                    \"username\": \"mikeyk\",\n                    \"full_name\": \"Mikey Krieger\",\n                    \"id\": \"4\",\n                    \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg\"\n                },\n                \"id\": \"8\"\n            }],\n            \"count\": 2\n        },\n        \"caption\": {\n            \"created_time\": \"1296710352\",\n            \"text\": \"Inside le truc #foodtruck\",\n            \"from\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin Systrom\",\n                \"type\": \"user\",\n                \"id\": \"3\"\n            },\n            \"id\": \"26621408\"\n        },\n        \"likes\": {\n            \"count\": 1,\n            \"data\": [{\n                \"username\": \"mikeyk\",\n                \"full_name\": \"Mikeyk\",\n                \"id\": \"4\",\n                \"profile_picture\": \"...\"\n            }]\n        },\n        \"link\": \"http://instagr.am/p/D/\",\n        \"user\": {\n            \"username\": \"kevin\",\n            \"full_name\": \"Kevin S\",\n            \"profile_picture\": \"...\",\n            \"bio\": \"...\",\n            \"website\": \"...\",\n            \"id\": \"3\"\n        },\n        \"created_time\": \"1279340983\",\n        \"images\": {\n            \"low_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_6.jpg\",\n                \"width\": 306,\n                \"height\": 306\n            },\n            \"thumbnail\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_5.jpg\",\n                \"width\": 150,\n                \"height\": 150\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_7.jpg\",\n                \"width\": 612,\n                \"height\": 612\n            }\n        },\n        \"id\": \"3\",\n        \"location\": {\n            \"id\": \"id\",\n            \"latitude\": -34,\n            \"longitude\": -53,\n            \"name\": \"some place\"\n        }\n    }\n}\n",
                       "strict": true,
                       "name": null,
                       "structuredValue": {
@@ -864,12 +747,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "meta": {
-                          "code": 200
-                        },
-                        "data": null
-                      },
+                      "value": "{\n    \"meta\": {\n        \"code\": 200\n    },\n    \"data\": null\n}\n",
                       "strict": true,
                       "name": null,
                       "structuredValue": {
@@ -930,12 +808,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "meta": {
-                          "code": 200
-                        },
-                        "data": null
-                      },
+                      "value": "{\n    \"meta\": {\n        \"code\": 200\n    },\n    \"data\": null\n}\n",
                       "strict": true,
                       "name": null,
                       "structuredValue": {
@@ -1275,191 +1148,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "data": [
-                          {
-                            "distance": 50,
-                            "location": {
-                              "id": "833",
-                              "latitude": 37.77956816727314,
-                              "longitude": -122.4138736724854,
-                              "street_address": "",
-                              "name": "Civic Center BART"
-                            },
-                            "comments": {
-                              "count": 16,
-                              "data": []
-                            },
-                            "caption": {
-                              "created_time": "1296710352",
-                              "text": "Inside le truc #foodtruck",
-                              "from": {
-                                "username": "kevin",
-                                "full_name": "Kevin Systrom",
-                                "type": "user",
-                                "id": "3"
-                              },
-                              "id": "26621408"
-                            },
-                            "link": "http://instagr.am/p/BXsFz/",
-                            "likes": {
-                              "count": 190,
-                              "data": [
-                                {
-                                  "username": "shayne",
-                                  "full_name": "Shayne Sweeney",
-                                  "id": "20",
-                                  "profile_picture": "..."
-                                },
-                                {}
-                              ]
-                            },
-                            "created_time": "1296748524",
-                            "images": {
-                              "low_resolution": {
-                                "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_6.jpg",
-                                "width": 306,
-                                "height": 306
-                              },
-                              "thumbnail": {
-                                "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_5.jpg",
-                                "width": 150,
-                                "height": 150
-                              },
-                              "standard_resolution": {
-                                "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_7.jpg",
-                                "width": 612,
-                                "height": 612
-                              }
-                            },
-                            "type": "image",
-                            "users_in_photo": [
-                              {
-                                "user": {
-                                  "username": "kevin",
-                                  "full_name": "Kevin S",
-                                  "id": "3",
-                                  "profile_picture": "..."
-                                },
-                                "position": {
-                                  "x": 0.315,
-                                  "y": 0.9111
-                                }
-                              }
-                            ],
-                            "filter": "Earlybird",
-                            "tags": [],
-                            "id": "22987123",
-                            "user": {
-                              "username": "kevin",
-                              "full_name": "Kevin S",
-                              "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
-                              "id": "3"
-                            }
-                          },
-                          {
-                            "distance": 50,
-                            "videos": {
-                              "low_resolution": {
-                                "url": "http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_102.mp4",
-                                "width": 480,
-                                "height": 480
-                              },
-                              "standard_resolution": {
-                                "url": "http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_101.mp4",
-                                "width": 640,
-                                "height": 640
-                              },
-                              "comments": {
-                                "data": [
-                                  {
-                                    "created_time": "1279332030",
-                                    "text": "Love the sign here",
-                                    "from": {
-                                      "username": "mikeyk",
-                                      "full_name": "Mikey Krieger",
-                                      "id": "4",
-                                      "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg"
-                                    },
-                                    "id": "8"
-                                  },
-                                  {
-                                    "created_time": "1279341004",
-                                    "text": "Chilako taco",
-                                    "from": {
-                                      "username": "kevin",
-                                      "full_name": "Kevin S",
-                                      "id": "3",
-                                      "profile_picture": "..."
-                                    },
-                                    "id": "3"
-                                  }
-                                ],
-                                "count": 2
-                              },
-                              "caption": {
-                                "created_time": "1296710352",
-                                "text": "Inside le truc #foodtruck",
-                                "from": {
-                                  "username": "kevin",
-                                  "full_name": "Kevin Systrom",
-                                  "type": "user",
-                                  "id": "3"
-                                },
-                                "id": "26621408"
-                              },
-                              "likes": {
-                                "count": 1,
-                                "data": [
-                                  {
-                                    "username": "mikeyk",
-                                    "full_name": "Mikeyk",
-                                    "id": "4",
-                                    "profile_picture": "..."
-                                  }
-                                ]
-                              },
-                              "link": "http://instagr.am/p/D/",
-                              "created_time": "1279340983",
-                              "images": {
-                                "low_resolution": {
-                                  "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_6.jpg",
-                                  "width": 306,
-                                  "height": 306
-                                },
-                                "thumbnail": {
-                                  "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_5.jpg",
-                                  "width": 150,
-                                  "height": 150
-                                },
-                                "standard_resolution": {
-                                  "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_7.jpg",
-                                  "width": 612,
-                                  "height": 612
-                                }
-                              },
-                              "type": "video",
-                              "users_in_photo": [],
-                              "filter": "Vesper",
-                              "tags": [],
-                              "id": "363839373298",
-                              "user": {
-                                "username": "kevin",
-                                "full_name": "Kevin S",
-                                "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
-                                "id": "3"
-                              },
-                              "location": {
-                                "id": "833",
-                                "latitude": 37.77956816727314,
-                                "longitude": -122.4138736724854,
-                                "street_address": "",
-                                "name": "Civic Center BART"
-                              }
-                            }
-                          }
-                        ]
-                      },
+                      "value": "{\n    \"data\": [{\n        \"distance\" : 50,\n        \"location\": {\n            \"id\": \"833\",\n            \"latitude\": 37.77956816727314,\n            \"longitude\": -122.41387367248539,\n            \"street_address\": \"\",\n            \"name\": \"Civic Center BART\"\n        },\n        \"comments\": {\n            \"count\": 16,\n            \"data\": [  ]\n        },\n        \"caption\":  {\n            \"created_time\": \"1296710352\",\n            \"text\": \"Inside le truc #foodtruck\",\n            \"from\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin Systrom\",\n                \"type\": \"user\",\n                \"id\": \"3\"\n            },\n            \"id\": \"26621408\"\n        },\n        \"link\": \"http://instagr.am/p/BXsFz/\",\n        \"likes\": {\n            \"count\": 190,\n            \"data\": [{\n                \"username\": \"shayne\",\n                \"full_name\": \"Shayne Sweeney\",\n                \"id\": \"20\",\n                \"profile_picture\": \"...\"\n            }, {}]\n        },\n        \"created_time\": \"1296748524\",\n        \"images\": {\n            \"low_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_6.jpg\",\n                \"width\": 306,\n                \"height\": 306\n            },\n            \"thumbnail\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_5.jpg\",\n                \"width\": 150,\n                \"height\": 150\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_7.jpg\",\n                \"width\": 612,\n                \"height\": 612\n            }\n        },\n        \"type\": \"image\",\n        \"users_in_photo\": [{\n            \"user\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin S\",\n                \"id\": \"3\",\n                \"profile_picture\": \"...\"\n            },\n            \"position\": {\n                \"x\": 0.315,\n                \"y\": 0.9111\n            }\n        }],\n        \"filter\": \"Earlybird\",\n        \"tags\": [],\n        \"id\": \"22987123\",\n        \"user\": {\n            \"username\": \"kevin\",\n            \"full_name\": \"Kevin S\",\n            \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg\",\n            \"id\": \"3\"\n        }\n    },\n    {\n        \"distance\" : 50,\n        \"videos\": {\n            \"low_resolution\": {\n                \"url\": \"http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_102.mp4\",\n                \"width\": 480,\n                \"height\": 480\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_101.mp4\",\n                \"width\": 640,\n                \"height\": 640\n            },\n        \"comments\": {\n            \"data\": [{\n                \"created_time\": \"1279332030\",\n                \"text\": \"Love the sign here\",\n                \"from\": {\n                    \"username\": \"mikeyk\",\n                    \"full_name\": \"Mikey Krieger\",\n                    \"id\": \"4\",\n                    \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg\"\n                },\n                \"id\": \"8\"\n            },\n            {\n                \"created_time\": \"1279341004\",\n                \"text\": \"Chilako taco\",\n                \"from\": {\n                    \"username\": \"kevin\",\n                    \"full_name\": \"Kevin S\",\n                    \"id\": \"3\",\n                    \"profile_picture\": \"...\"\n                },\n                \"id\": \"3\"\n            }],\n            \"count\": 2\n        },\n        \"caption\": {\n            \"created_time\": \"1296710352\",\n            \"text\": \"Inside le truc #foodtruck\",\n            \"from\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin Systrom\",\n                \"type\": \"user\",\n                \"id\": \"3\"\n            },\n            \"id\": \"26621408\"\n        },\n        \"likes\": {\n            \"count\": 1,\n            \"data\": [{\n                \"username\": \"mikeyk\",\n                \"full_name\": \"Mikeyk\",\n                \"id\": \"4\",\n                \"profile_picture\": \"...\"\n            }]\n        },\n        \"link\": \"http://instagr.am/p/D/\",\n        \"created_time\": \"1279340983\",\n        \"images\": {\n            \"low_resolution\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_6.jpg\",\n                \"width\": 306,\n                \"height\": 306\n            },\n            \"thumbnail\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_5.jpg\",\n                \"width\": 150,\n                \"height\": 150\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_7.jpg\",\n                \"width\": 612,\n                \"height\": 612\n            }\n        },\n        \"type\": \"video\",\n        \"users_in_photo\": [],\n        \"filter\": \"Vesper\",\n        \"tags\": [],\n        \"id\": \"363839373298\",\n        \"user\": {\n            \"username\": \"kevin\",\n            \"full_name\": \"Kevin S\",\n            \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg\",\n            \"id\": \"3\"\n        },\n            \"location\": {\n                \"id\": \"833\",\n                \"latitude\": 37.77956816727314,\n                \"longitude\": -122.41387367248539,\n                \"street_address\": \"\",\n                \"name\": \"Civic Center BART\"\n            }\n    }}]\n}\n",
                       "strict": true,
                       "name": null,
                       "structuredValue": {
@@ -1846,7 +1535,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": 1,
+                      "value": "1",
                       "strict": true,
                       "name": null,
                       "structuredValue": 1
@@ -2008,7 +1697,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": 1,
+                          "value": "1",
                           "strict": true,
                           "name": null,
                           "structuredValue": 1
@@ -2143,12 +1832,7 @@
                               }
                             },
                             "structuredExample": {
-                              "value": {
-                                "meta": {
-                                  "code": 200
-                                },
-                                "data": null
-                              },
+                              "value": "{\n    \"meta\": {\n        \"code\": 200\n    },\n    \"data\": null\n}\n",
                               "strict": true,
                               "name": null,
                               "structuredValue": {
@@ -2296,12 +1980,7 @@
                                   }
                                 },
                                 "structuredExample": {
-                                  "value": {
-                                    "meta": {
-                                      "code": 200
-                                    },
-                                    "data": null
-                                  },
+                                  "value": "{\n    \"meta\": {\n        \"code\": 200\n    },\n    \"data\": null\n}\n",
                                   "strict": true,
                                   "name": null,
                                   "structuredValue": {
@@ -2435,7 +2114,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": 1,
+                          "value": "1",
                           "strict": true,
                           "name": null,
                           "structuredValue": 1
@@ -2570,12 +2249,7 @@
                               }
                             },
                             "structuredExample": {
-                              "value": {
-                                "meta": {
-                                  "code": 200
-                                },
-                                "data": null
-                              },
+                              "value": "{\n    \"meta\": {\n        \"code\": 200\n    },\n    \"data\": null\n}\n",
                               "strict": true,
                               "name": null,
                               "structuredValue": {
@@ -2652,12 +2326,7 @@
                               }
                             },
                             "structuredExample": {
-                              "value": {
-                                "meta": {
-                                  "code": 200
-                                },
-                                "data": null
-                              },
+                              "value": "{\n    \"meta\": {\n        \"code\": 200\n    },\n    \"data\": null\n}\n",
                               "strict": true,
                               "name": null,
                               "structuredValue": {
@@ -2889,7 +2558,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": 1,
+                      "value": "1",
                       "strict": true,
                       "name": null,
                       "structuredValue": 1
@@ -3049,100 +2718,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": {
-                            "data": {
-                              "distance": 50,
-                              "type": "image",
-                              "users_in_photo": [
-                                {
-                                  "user": {
-                                    "username": "kevin",
-                                    "full_name": "Kevin S",
-                                    "id": "3",
-                                    "profile_picture": "..."
-                                  },
-                                  "position": {
-                                    "x": 0.315,
-                                    "y": 0.9111
-                                  }
-                                }
-                              ],
-                              "filter": "Walden",
-                              "tags": [],
-                              "comments": {
-                                "data": [
-                                  {
-                                    "created_time": "1279332030",
-                                    "text": "Love the sign here",
-                                    "from": {
-                                      "username": "mikeyk",
-                                      "full_name": "Mikey Krieger",
-                                      "id": "4",
-                                      "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg"
-                                    },
-                                    "id": "8"
-                                  }
-                                ],
-                                "count": 2
-                              },
-                              "caption": {
-                                "created_time": "1296710352",
-                                "text": "Inside le truc #foodtruck",
-                                "from": {
-                                  "username": "kevin",
-                                  "full_name": "Kevin Systrom",
-                                  "type": "user",
-                                  "id": "3"
-                                },
-                                "id": "26621408"
-                              },
-                              "likes": {
-                                "count": 1,
-                                "data": [
-                                  {
-                                    "username": "mikeyk",
-                                    "full_name": "Mikeyk",
-                                    "id": "4",
-                                    "profile_picture": "..."
-                                  }
-                                ]
-                              },
-                              "link": "http://instagr.am/p/D/",
-                              "user": {
-                                "username": "kevin",
-                                "full_name": "Kevin S",
-                                "profile_picture": "...",
-                                "bio": "...",
-                                "website": "...",
-                                "id": "3"
-                              },
-                              "created_time": "1279340983",
-                              "images": {
-                                "low_resolution": {
-                                  "url": "http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_6.jpg",
-                                  "width": 306,
-                                  "height": 306
-                                },
-                                "thumbnail": {
-                                  "url": "http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_5.jpg",
-                                  "width": 150,
-                                  "height": 150
-                                },
-                                "standard_resolution": {
-                                  "url": "http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_7.jpg",
-                                  "width": 612,
-                                  "height": 612
-                                }
-                              },
-                              "id": "3",
-                              "location": {
-                                "id": "id",
-                                "latitude": -34,
-                                "longitude": -53,
-                                "name": "some place"
-                              }
-                            }
-                          },
+                          "value": "{\n    \"data\": {\n        \"distance\" : 50,\n        \"type\": \"image\",\n        \"users_in_photo\": [{\n            \"user\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin S\",\n                \"id\": \"3\",\n                \"profile_picture\": \"...\"\n            },\n            \"position\": {\n                \"x\": 0.315,\n                \"y\": 0.9111\n            }\n        }],\n        \"filter\": \"Walden\",\n        \"tags\": [],\n        \"comments\": {\n            \"data\": [{\n                \"created_time\": \"1279332030\",\n                \"text\": \"Love the sign here\",\n                \"from\": {\n                    \"username\": \"mikeyk\",\n                    \"full_name\": \"Mikey Krieger\",\n                    \"id\": \"4\",\n                    \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg\"\n                },\n                \"id\": \"8\"\n            }],\n            \"count\": 2\n        },\n        \"caption\": {\n            \"created_time\": \"1296710352\",\n            \"text\": \"Inside le truc #foodtruck\",\n            \"from\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin Systrom\",\n                \"type\": \"user\",\n                \"id\": \"3\"\n            },\n            \"id\": \"26621408\"\n        },\n        \"likes\": {\n            \"count\": 1,\n            \"data\": [{\n                \"username\": \"mikeyk\",\n                \"full_name\": \"Mikeyk\",\n                \"id\": \"4\",\n                \"profile_picture\": \"...\"\n            }]\n        },\n        \"link\": \"http://instagr.am/p/D/\",\n        \"user\": {\n            \"username\": \"kevin\",\n            \"full_name\": \"Kevin S\",\n            \"profile_picture\": \"...\",\n            \"bio\": \"...\",\n            \"website\": \"...\",\n            \"id\": \"3\"\n        },\n        \"created_time\": \"1279340983\",\n        \"images\": {\n            \"low_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_6.jpg\",\n                \"width\": 306,\n                \"height\": 306\n            },\n            \"thumbnail\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_5.jpg\",\n                \"width\": 150,\n                \"height\": 150\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_7.jpg\",\n                \"width\": 612,\n                \"height\": 612\n            }\n        },\n        \"id\": \"3\",\n        \"location\": {\n            \"id\": \"id\",\n            \"latitude\": -34,\n            \"longitude\": -53,\n            \"name\": \"some place\"\n        }\n    }\n}\n",
                           "strict": true,
                           "name": null,
                           "structuredValue": {
@@ -3324,7 +2900,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": 1,
+                      "value": "1",
                       "strict": true,
                       "name": null,
                       "structuredValue": 1
@@ -3484,100 +3060,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": {
-                            "data": {
-                              "distance": 50,
-                              "type": "image",
-                              "users_in_photo": [
-                                {
-                                  "user": {
-                                    "username": "kevin",
-                                    "full_name": "Kevin S",
-                                    "id": "3",
-                                    "profile_picture": "..."
-                                  },
-                                  "position": {
-                                    "x": 0.315,
-                                    "y": 0.9111
-                                  }
-                                }
-                              ],
-                              "filter": "Walden",
-                              "tags": [],
-                              "comments": {
-                                "data": [
-                                  {
-                                    "created_time": "1279332030",
-                                    "text": "Love the sign here",
-                                    "from": {
-                                      "username": "mikeyk",
-                                      "full_name": "Mikey Krieger",
-                                      "id": "4",
-                                      "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg"
-                                    },
-                                    "id": "8"
-                                  }
-                                ],
-                                "count": 2
-                              },
-                              "caption": {
-                                "created_time": "1296710352",
-                                "text": "Inside le truc #foodtruck",
-                                "from": {
-                                  "username": "kevin",
-                                  "full_name": "Kevin Systrom",
-                                  "type": "user",
-                                  "id": "3"
-                                },
-                                "id": "26621408"
-                              },
-                              "likes": {
-                                "count": 1,
-                                "data": [
-                                  {
-                                    "username": "mikeyk",
-                                    "full_name": "Mikeyk",
-                                    "id": "4",
-                                    "profile_picture": "..."
-                                  }
-                                ]
-                              },
-                              "link": "http://instagr.am/p/D/",
-                              "user": {
-                                "username": "kevin",
-                                "full_name": "Kevin S",
-                                "profile_picture": "...",
-                                "bio": "...",
-                                "website": "...",
-                                "id": "3"
-                              },
-                              "created_time": "1279340983",
-                              "images": {
-                                "low_resolution": {
-                                  "url": "http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_6.jpg",
-                                  "width": 306,
-                                  "height": 306
-                                },
-                                "thumbnail": {
-                                  "url": "http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_5.jpg",
-                                  "width": 150,
-                                  "height": 150
-                                },
-                                "standard_resolution": {
-                                  "url": "http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_7.jpg",
-                                  "width": 612,
-                                  "height": 612
-                                }
-                              },
-                              "id": "3",
-                              "location": {
-                                "id": "id",
-                                "latitude": -34,
-                                "longitude": -53,
-                                "name": "some place"
-                              }
-                            }
-                          },
+                          "value": "{\n    \"data\": {\n        \"distance\" : 50,\n        \"type\": \"image\",\n        \"users_in_photo\": [{\n            \"user\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin S\",\n                \"id\": \"3\",\n                \"profile_picture\": \"...\"\n            },\n            \"position\": {\n                \"x\": 0.315,\n                \"y\": 0.9111\n            }\n        }],\n        \"filter\": \"Walden\",\n        \"tags\": [],\n        \"comments\": {\n            \"data\": [{\n                \"created_time\": \"1279332030\",\n                \"text\": \"Love the sign here\",\n                \"from\": {\n                    \"username\": \"mikeyk\",\n                    \"full_name\": \"Mikey Krieger\",\n                    \"id\": \"4\",\n                    \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg\"\n                },\n                \"id\": \"8\"\n            }],\n            \"count\": 2\n        },\n        \"caption\": {\n            \"created_time\": \"1296710352\",\n            \"text\": \"Inside le truc #foodtruck\",\n            \"from\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin Systrom\",\n                \"type\": \"user\",\n                \"id\": \"3\"\n            },\n            \"id\": \"26621408\"\n        },\n        \"likes\": {\n            \"count\": 1,\n            \"data\": [{\n                \"username\": \"mikeyk\",\n                \"full_name\": \"Mikeyk\",\n                \"id\": \"4\",\n                \"profile_picture\": \"...\"\n            }]\n        },\n        \"link\": \"http://instagr.am/p/D/\",\n        \"user\": {\n            \"username\": \"kevin\",\n            \"full_name\": \"Kevin S\",\n            \"profile_picture\": \"...\",\n            \"bio\": \"...\",\n            \"website\": \"...\",\n            \"id\": \"3\"\n        },\n        \"created_time\": \"1279340983\",\n        \"images\": {\n            \"low_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_6.jpg\",\n                \"width\": 306,\n                \"height\": 306\n            },\n            \"thumbnail\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_5.jpg\",\n                \"width\": 150,\n                \"height\": 150\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2010/07/16/4de37e03aa4b4372843a7eb33fa41cad_7.jpg\",\n                \"width\": 612,\n                \"height\": 612\n            }\n        },\n        \"id\": \"3\",\n        \"location\": {\n            \"id\": \"id\",\n            \"latitude\": -34,\n            \"longitude\": -53,\n            \"name\": \"some place\"\n        }\n    }\n}\n",
                           "strict": true,
                           "name": null,
                           "structuredValue": {
@@ -3780,7 +3263,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": 1,
+                      "value": "1",
                       "strict": true,
                       "name": null,
                       "structuredValue": 1
@@ -3988,7 +3471,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": 1,
+                          "value": "1",
                           "strict": true,
                           "name": null,
                           "structuredValue": 1
@@ -4182,7 +3665,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": 1,
+                      "value": "1",
                       "strict": true,
                       "name": null,
                       "structuredValue": 1
@@ -4352,7 +3835,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": 1,
+                      "value": "1",
                       "strict": true,
                       "name": null,
                       "structuredValue": 1
@@ -4514,7 +3997,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": 1,
+                          "value": "1",
                           "strict": true,
                           "name": null,
                           "structuredValue": 1
@@ -4605,31 +4088,7 @@
                               }
                             },
                             "structuredExample": {
-                              "value": {
-                                "data": [
-                                  {
-                                    "username": "jack",
-                                    "first_name": "Jack",
-                                    "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_66_75sq.jpg",
-                                    "id": "66",
-                                    "last_name": "Dorsey"
-                                  },
-                                  {
-                                    "username": "sammyjack",
-                                    "first_name": "Sammy",
-                                    "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_29648_75sq_1294520029.jpg",
-                                    "id": "29648",
-                                    "last_name": "Jack"
-                                  },
-                                  {
-                                    "username": "jacktiddy",
-                                    "first_name": "Jack",
-                                    "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_13096_75sq_1286441317.jpg",
-                                    "id": "13096",
-                                    "last_name": "Tiddy"
-                                  }
-                                ]
-                              },
+                              "value": "{\n    \"data\": [{\n        \"username\": \"jack\",\n        \"first_name\": \"Jack\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_66_75sq.jpg\",\n        \"id\": \"66\",\n        \"last_name\": \"Dorsey\"\n    },\n    {\n        \"username\": \"sammyjack\",\n        \"first_name\": \"Sammy\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_29648_75sq_1294520029.jpg\",\n        \"id\": \"29648\",\n        \"last_name\": \"Jack\"\n    },\n    {\n        \"username\": \"jacktiddy\",\n        \"first_name\": \"Jack\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_13096_75sq_1286441317.jpg\",\n        \"id\": \"13096\",\n        \"last_name\": \"Tiddy\"\n    }]\n}",
                               "strict": true,
                               "name": null,
                               "structuredValue": {
@@ -4747,7 +4206,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": 1,
+                          "value": "1",
                           "strict": true,
                           "name": null,
                           "structuredValue": 1
@@ -4838,31 +4297,7 @@
                               }
                             },
                             "structuredExample": {
-                              "value": {
-                                "data": [
-                                  {
-                                    "username": "jack",
-                                    "first_name": "Jack",
-                                    "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_66_75sq.jpg",
-                                    "id": "66",
-                                    "last_name": "Dorsey"
-                                  },
-                                  {
-                                    "username": "sammyjack",
-                                    "first_name": "Sammy",
-                                    "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_29648_75sq_1294520029.jpg",
-                                    "id": "29648",
-                                    "last_name": "Jack"
-                                  },
-                                  {
-                                    "username": "jacktiddy",
-                                    "first_name": "Jack",
-                                    "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_13096_75sq_1286441317.jpg",
-                                    "id": "13096",
-                                    "last_name": "Tiddy"
-                                  }
-                                ]
-                              },
+                              "value": "{\n    \"data\": [{\n        \"username\": \"jack\",\n        \"first_name\": \"Jack\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_66_75sq.jpg\",\n        \"id\": \"66\",\n        \"last_name\": \"Dorsey\"\n    },\n    {\n        \"username\": \"sammyjack\",\n        \"first_name\": \"Sammy\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_29648_75sq_1294520029.jpg\",\n        \"id\": \"29648\",\n        \"last_name\": \"Jack\"\n    },\n    {\n        \"username\": \"jacktiddy\",\n        \"first_name\": \"Jack\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_13096_75sq_1286441317.jpg\",\n        \"id\": \"13096\",\n        \"last_name\": \"Tiddy\"\n    }]\n}",
                               "strict": true,
                               "name": null,
                               "structuredValue": {
@@ -5072,7 +4507,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": 1,
+                          "value": "1",
                           "strict": true,
                           "name": null,
                           "structuredValue": 1
@@ -5323,191 +4758,7 @@
                               }
                             },
                             "structuredExample": {
-                              "value": {
-                                "data": [
-                                  {
-                                    "distance": 50,
-                                    "location": {
-                                      "id": "833",
-                                      "latitude": 37.77956816727314,
-                                      "longitude": -122.4138736724854,
-                                      "street_address": "",
-                                      "name": "Civic Center BART"
-                                    },
-                                    "comments": {
-                                      "count": 16,
-                                      "data": []
-                                    },
-                                    "caption": {
-                                      "created_time": "1296710352",
-                                      "text": "Inside le truc #foodtruck",
-                                      "from": {
-                                        "username": "kevin",
-                                        "full_name": "Kevin Systrom",
-                                        "type": "user",
-                                        "id": "3"
-                                      },
-                                      "id": "26621408"
-                                    },
-                                    "link": "http://instagr.am/p/BXsFz/",
-                                    "likes": {
-                                      "count": 190,
-                                      "data": [
-                                        {
-                                          "username": "shayne",
-                                          "full_name": "Shayne Sweeney",
-                                          "id": "20",
-                                          "profile_picture": "..."
-                                        },
-                                        {}
-                                      ]
-                                    },
-                                    "created_time": "1296748524",
-                                    "images": {
-                                      "low_resolution": {
-                                        "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_6.jpg",
-                                        "width": 306,
-                                        "height": 306
-                                      },
-                                      "thumbnail": {
-                                        "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_5.jpg",
-                                        "width": 150,
-                                        "height": 150
-                                      },
-                                      "standard_resolution": {
-                                        "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_7.jpg",
-                                        "width": 612,
-                                        "height": 612
-                                      }
-                                    },
-                                    "type": "image",
-                                    "users_in_photo": [
-                                      {
-                                        "user": {
-                                          "username": "kevin",
-                                          "full_name": "Kevin S",
-                                          "id": "3",
-                                          "profile_picture": "..."
-                                        },
-                                        "position": {
-                                          "x": 0.315,
-                                          "y": 0.9111
-                                        }
-                                      }
-                                    ],
-                                    "filter": "Earlybird",
-                                    "tags": [],
-                                    "id": "22987123",
-                                    "user": {
-                                      "username": "kevin",
-                                      "full_name": "Kevin S",
-                                      "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
-                                      "id": "3"
-                                    }
-                                  },
-                                  {
-                                    "distance": 50,
-                                    "videos": {
-                                      "low_resolution": {
-                                        "url": "http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_102.mp4",
-                                        "width": 480,
-                                        "height": 480
-                                      },
-                                      "standard_resolution": {
-                                        "url": "http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_101.mp4",
-                                        "width": 640,
-                                        "height": 640
-                                      },
-                                      "comments": {
-                                        "data": [
-                                          {
-                                            "created_time": "1279332030",
-                                            "text": "Love the sign here",
-                                            "from": {
-                                              "username": "mikeyk",
-                                              "full_name": "Mikey Krieger",
-                                              "id": "4",
-                                              "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg"
-                                            },
-                                            "id": "8"
-                                          },
-                                          {
-                                            "created_time": "1279341004",
-                                            "text": "Chilako taco",
-                                            "from": {
-                                              "username": "kevin",
-                                              "full_name": "Kevin S",
-                                              "id": "3",
-                                              "profile_picture": "..."
-                                            },
-                                            "id": "3"
-                                          }
-                                        ],
-                                        "count": 2
-                                      },
-                                      "caption": {
-                                        "created_time": "1296710352",
-                                        "text": "Inside le truc #foodtruck",
-                                        "from": {
-                                          "username": "kevin",
-                                          "full_name": "Kevin Systrom",
-                                          "type": "user",
-                                          "id": "3"
-                                        },
-                                        "id": "26621408"
-                                      },
-                                      "likes": {
-                                        "count": 1,
-                                        "data": [
-                                          {
-                                            "username": "mikeyk",
-                                            "full_name": "Mikeyk",
-                                            "id": "4",
-                                            "profile_picture": "..."
-                                          }
-                                        ]
-                                      },
-                                      "link": "http://instagr.am/p/D/",
-                                      "created_time": "1279340983",
-                                      "images": {
-                                        "low_resolution": {
-                                          "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_6.jpg",
-                                          "width": 306,
-                                          "height": 306
-                                        },
-                                        "thumbnail": {
-                                          "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_5.jpg",
-                                          "width": 150,
-                                          "height": 150
-                                        },
-                                        "standard_resolution": {
-                                          "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_7.jpg",
-                                          "width": 612,
-                                          "height": 612
-                                        }
-                                      },
-                                      "type": "video",
-                                      "users_in_photo": [],
-                                      "filter": "Vesper",
-                                      "tags": [],
-                                      "id": "363839373298",
-                                      "user": {
-                                        "username": "kevin",
-                                        "full_name": "Kevin S",
-                                        "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
-                                        "id": "3"
-                                      },
-                                      "location": {
-                                        "id": "833",
-                                        "latitude": 37.77956816727314,
-                                        "longitude": -122.4138736724854,
-                                        "street_address": "",
-                                        "name": "Civic Center BART"
-                                      }
-                                    }
-                                  }
-                                ]
-                              },
+                              "value": "{\n    \"data\": [{\n        \"distance\" : 50,\n        \"location\": {\n            \"id\": \"833\",\n            \"latitude\": 37.77956816727314,\n            \"longitude\": -122.41387367248539,\n            \"street_address\": \"\",\n            \"name\": \"Civic Center BART\"\n        },\n        \"comments\": {\n            \"count\": 16,\n            \"data\": [  ]\n        },\n        \"caption\":  {\n            \"created_time\": \"1296710352\",\n            \"text\": \"Inside le truc #foodtruck\",\n            \"from\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin Systrom\",\n                \"type\": \"user\",\n                \"id\": \"3\"\n            },\n            \"id\": \"26621408\"\n        },\n        \"link\": \"http://instagr.am/p/BXsFz/\",\n        \"likes\": {\n            \"count\": 190,\n            \"data\": [{\n                \"username\": \"shayne\",\n                \"full_name\": \"Shayne Sweeney\",\n                \"id\": \"20\",\n                \"profile_picture\": \"...\"\n            }, {}]\n        },\n        \"created_time\": \"1296748524\",\n        \"images\": {\n            \"low_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_6.jpg\",\n                \"width\": 306,\n                \"height\": 306\n            },\n            \"thumbnail\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_5.jpg\",\n                \"width\": 150,\n                \"height\": 150\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_7.jpg\",\n                \"width\": 612,\n                \"height\": 612\n            }\n        },\n        \"type\": \"image\",\n        \"users_in_photo\": [{\n            \"user\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin S\",\n                \"id\": \"3\",\n                \"profile_picture\": \"...\"\n            },\n            \"position\": {\n                \"x\": 0.315,\n                \"y\": 0.9111\n            }\n        }],\n        \"filter\": \"Earlybird\",\n        \"tags\": [],\n        \"id\": \"22987123\",\n        \"user\": {\n            \"username\": \"kevin\",\n            \"full_name\": \"Kevin S\",\n            \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg\",\n            \"id\": \"3\"\n        }\n    },\n    {\n        \"distance\" : 50,\n        \"videos\": {\n            \"low_resolution\": {\n                \"url\": \"http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_102.mp4\",\n                \"width\": 480,\n                \"height\": 480\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_101.mp4\",\n                \"width\": 640,\n                \"height\": 640\n            },\n        \"comments\": {\n            \"data\": [{\n                \"created_time\": \"1279332030\",\n                \"text\": \"Love the sign here\",\n                \"from\": {\n                    \"username\": \"mikeyk\",\n                    \"full_name\": \"Mikey Krieger\",\n                    \"id\": \"4\",\n                    \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg\"\n                },\n                \"id\": \"8\"\n            },\n            {\n                \"created_time\": \"1279341004\",\n                \"text\": \"Chilako taco\",\n                \"from\": {\n                    \"username\": \"kevin\",\n                    \"full_name\": \"Kevin S\",\n                    \"id\": \"3\",\n                    \"profile_picture\": \"...\"\n                },\n                \"id\": \"3\"\n            }],\n            \"count\": 2\n        },\n        \"caption\": {\n            \"created_time\": \"1296710352\",\n            \"text\": \"Inside le truc #foodtruck\",\n            \"from\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin Systrom\",\n                \"type\": \"user\",\n                \"id\": \"3\"\n            },\n            \"id\": \"26621408\"\n        },\n        \"likes\": {\n            \"count\": 1,\n            \"data\": [{\n                \"username\": \"mikeyk\",\n                \"full_name\": \"Mikeyk\",\n                \"id\": \"4\",\n                \"profile_picture\": \"...\"\n            }]\n        },\n        \"link\": \"http://instagr.am/p/D/\",\n        \"created_time\": \"1279340983\",\n        \"images\": {\n            \"low_resolution\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_6.jpg\",\n                \"width\": 306,\n                \"height\": 306\n            },\n            \"thumbnail\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_5.jpg\",\n                \"width\": 150,\n                \"height\": 150\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_7.jpg\",\n                \"width\": 612,\n                \"height\": 612\n            }\n        },\n        \"type\": \"video\",\n        \"users_in_photo\": [],\n        \"filter\": \"Vesper\",\n        \"tags\": [],\n        \"id\": \"363839373298\",\n        \"user\": {\n            \"username\": \"kevin\",\n            \"full_name\": \"Kevin S\",\n            \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg\",\n            \"id\": \"3\"\n        },\n            \"location\": {\n                \"id\": \"833\",\n                \"latitude\": 37.77956816727314,\n                \"longitude\": -122.41387367248539,\n                \"street_address\": \"\",\n                \"name\": \"Civic Center BART\"\n            }\n    }}]\n}\n",
                               "strict": true,
                               "name": null,
                               "structuredValue": {
@@ -5781,7 +5032,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": 1,
+                          "value": "1",
                           "strict": true,
                           "name": null,
                           "structuredValue": 1
@@ -5916,12 +5167,7 @@
                               }
                             },
                             "structuredExample": {
-                              "value": {
-                                "meta": {
-                                  "code": 200
-                                },
-                                "data": null
-                              },
+                              "value": "{\n    \"meta\": {\n        \"code\": 200\n    },\n    \"data\": null\n}\n",
                               "strict": true,
                               "name": null,
                               "structuredValue": {
@@ -6125,7 +5371,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": 10,
+                      "value": "10",
                       "strict": true,
                       "name": null,
                       "structuredValue": 10
@@ -6216,31 +5462,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": {
-                            "data": [
-                              {
-                                "username": "jack",
-                                "first_name": "Jack",
-                                "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_66_75sq.jpg",
-                                "id": "66",
-                                "last_name": "Dorsey"
-                              },
-                              {
-                                "username": "sammyjack",
-                                "first_name": "Sammy",
-                                "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_29648_75sq_1294520029.jpg",
-                                "id": "29648",
-                                "last_name": "Jack"
-                              },
-                              {
-                                "username": "jacktiddy",
-                                "first_name": "Jack",
-                                "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_13096_75sq_1286441317.jpg",
-                                "id": "13096",
-                                "last_name": "Tiddy"
-                              }
-                            ]
-                          },
+                          "value": "{\n    \"data\": [{\n        \"username\": \"jack\",\n        \"first_name\": \"Jack\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_66_75sq.jpg\",\n        \"id\": \"66\",\n        \"last_name\": \"Dorsey\"\n    },\n    {\n        \"username\": \"sammyjack\",\n        \"first_name\": \"Sammy\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_29648_75sq_1294520029.jpg\",\n        \"id\": \"29648\",\n        \"last_name\": \"Jack\"\n    },\n    {\n        \"username\": \"jacktiddy\",\n        \"first_name\": \"Jack\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_13096_75sq_1286441317.jpg\",\n        \"id\": \"13096\",\n        \"last_name\": \"Tiddy\"\n    }]\n}",
                           "strict": true,
                           "name": null,
                           "structuredValue": {
@@ -6358,7 +5580,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": 1,
+                      "value": "1",
                       "strict": true,
                       "name": null,
                       "structuredValue": 1
@@ -6552,7 +5774,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": 1,
+                          "value": "1",
                           "strict": true,
                           "name": null,
                           "structuredValue": 1
@@ -6803,191 +6025,7 @@
                               }
                             },
                             "structuredExample": {
-                              "value": {
-                                "data": [
-                                  {
-                                    "distance": 50,
-                                    "location": {
-                                      "id": "833",
-                                      "latitude": 37.77956816727314,
-                                      "longitude": -122.4138736724854,
-                                      "street_address": "",
-                                      "name": "Civic Center BART"
-                                    },
-                                    "comments": {
-                                      "count": 16,
-                                      "data": []
-                                    },
-                                    "caption": {
-                                      "created_time": "1296710352",
-                                      "text": "Inside le truc #foodtruck",
-                                      "from": {
-                                        "username": "kevin",
-                                        "full_name": "Kevin Systrom",
-                                        "type": "user",
-                                        "id": "3"
-                                      },
-                                      "id": "26621408"
-                                    },
-                                    "link": "http://instagr.am/p/BXsFz/",
-                                    "likes": {
-                                      "count": 190,
-                                      "data": [
-                                        {
-                                          "username": "shayne",
-                                          "full_name": "Shayne Sweeney",
-                                          "id": "20",
-                                          "profile_picture": "..."
-                                        },
-                                        {}
-                                      ]
-                                    },
-                                    "created_time": "1296748524",
-                                    "images": {
-                                      "low_resolution": {
-                                        "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_6.jpg",
-                                        "width": 306,
-                                        "height": 306
-                                      },
-                                      "thumbnail": {
-                                        "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_5.jpg",
-                                        "width": 150,
-                                        "height": 150
-                                      },
-                                      "standard_resolution": {
-                                        "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_7.jpg",
-                                        "width": 612,
-                                        "height": 612
-                                      }
-                                    },
-                                    "type": "image",
-                                    "users_in_photo": [
-                                      {
-                                        "user": {
-                                          "username": "kevin",
-                                          "full_name": "Kevin S",
-                                          "id": "3",
-                                          "profile_picture": "..."
-                                        },
-                                        "position": {
-                                          "x": 0.315,
-                                          "y": 0.9111
-                                        }
-                                      }
-                                    ],
-                                    "filter": "Earlybird",
-                                    "tags": [],
-                                    "id": "22987123",
-                                    "user": {
-                                      "username": "kevin",
-                                      "full_name": "Kevin S",
-                                      "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
-                                      "id": "3"
-                                    }
-                                  },
-                                  {
-                                    "distance": 50,
-                                    "videos": {
-                                      "low_resolution": {
-                                        "url": "http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_102.mp4",
-                                        "width": 480,
-                                        "height": 480
-                                      },
-                                      "standard_resolution": {
-                                        "url": "http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_101.mp4",
-                                        "width": 640,
-                                        "height": 640
-                                      },
-                                      "comments": {
-                                        "data": [
-                                          {
-                                            "created_time": "1279332030",
-                                            "text": "Love the sign here",
-                                            "from": {
-                                              "username": "mikeyk",
-                                              "full_name": "Mikey Krieger",
-                                              "id": "4",
-                                              "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg"
-                                            },
-                                            "id": "8"
-                                          },
-                                          {
-                                            "created_time": "1279341004",
-                                            "text": "Chilako taco",
-                                            "from": {
-                                              "username": "kevin",
-                                              "full_name": "Kevin S",
-                                              "id": "3",
-                                              "profile_picture": "..."
-                                            },
-                                            "id": "3"
-                                          }
-                                        ],
-                                        "count": 2
-                                      },
-                                      "caption": {
-                                        "created_time": "1296710352",
-                                        "text": "Inside le truc #foodtruck",
-                                        "from": {
-                                          "username": "kevin",
-                                          "full_name": "Kevin Systrom",
-                                          "type": "user",
-                                          "id": "3"
-                                        },
-                                        "id": "26621408"
-                                      },
-                                      "likes": {
-                                        "count": 1,
-                                        "data": [
-                                          {
-                                            "username": "mikeyk",
-                                            "full_name": "Mikeyk",
-                                            "id": "4",
-                                            "profile_picture": "..."
-                                          }
-                                        ]
-                                      },
-                                      "link": "http://instagr.am/p/D/",
-                                      "created_time": "1279340983",
-                                      "images": {
-                                        "low_resolution": {
-                                          "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_6.jpg",
-                                          "width": 306,
-                                          "height": 306
-                                        },
-                                        "thumbnail": {
-                                          "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_5.jpg",
-                                          "width": 150,
-                                          "height": 150
-                                        },
-                                        "standard_resolution": {
-                                          "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_7.jpg",
-                                          "width": 612,
-                                          "height": 612
-                                        }
-                                      },
-                                      "type": "video",
-                                      "users_in_photo": [],
-                                      "filter": "Vesper",
-                                      "tags": [],
-                                      "id": "363839373298",
-                                      "user": {
-                                        "username": "kevin",
-                                        "full_name": "Kevin S",
-                                        "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
-                                        "id": "3"
-                                      },
-                                      "location": {
-                                        "id": "833",
-                                        "latitude": 37.77956816727314,
-                                        "longitude": -122.4138736724854,
-                                        "street_address": "",
-                                        "name": "Civic Center BART"
-                                      }
-                                    }
-                                  }
-                                ]
-                              },
+                              "value": "{\n    \"data\": [{\n        \"distance\" : 50,\n        \"location\": {\n            \"id\": \"833\",\n            \"latitude\": 37.77956816727314,\n            \"longitude\": -122.41387367248539,\n            \"street_address\": \"\",\n            \"name\": \"Civic Center BART\"\n        },\n        \"comments\": {\n            \"count\": 16,\n            \"data\": [  ]\n        },\n        \"caption\":  {\n            \"created_time\": \"1296710352\",\n            \"text\": \"Inside le truc #foodtruck\",\n            \"from\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin Systrom\",\n                \"type\": \"user\",\n                \"id\": \"3\"\n            },\n            \"id\": \"26621408\"\n        },\n        \"link\": \"http://instagr.am/p/BXsFz/\",\n        \"likes\": {\n            \"count\": 190,\n            \"data\": [{\n                \"username\": \"shayne\",\n                \"full_name\": \"Shayne Sweeney\",\n                \"id\": \"20\",\n                \"profile_picture\": \"...\"\n            }, {}]\n        },\n        \"created_time\": \"1296748524\",\n        \"images\": {\n            \"low_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_6.jpg\",\n                \"width\": 306,\n                \"height\": 306\n            },\n            \"thumbnail\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_5.jpg\",\n                \"width\": 150,\n                \"height\": 150\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_7.jpg\",\n                \"width\": 612,\n                \"height\": 612\n            }\n        },\n        \"type\": \"image\",\n        \"users_in_photo\": [{\n            \"user\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin S\",\n                \"id\": \"3\",\n                \"profile_picture\": \"...\"\n            },\n            \"position\": {\n                \"x\": 0.315,\n                \"y\": 0.9111\n            }\n        }],\n        \"filter\": \"Earlybird\",\n        \"tags\": [],\n        \"id\": \"22987123\",\n        \"user\": {\n            \"username\": \"kevin\",\n            \"full_name\": \"Kevin S\",\n            \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg\",\n            \"id\": \"3\"\n        }\n    },\n    {\n        \"distance\" : 50,\n        \"videos\": {\n            \"low_resolution\": {\n                \"url\": \"http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_102.mp4\",\n                \"width\": 480,\n                \"height\": 480\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_101.mp4\",\n                \"width\": 640,\n                \"height\": 640\n            },\n        \"comments\": {\n            \"data\": [{\n                \"created_time\": \"1279332030\",\n                \"text\": \"Love the sign here\",\n                \"from\": {\n                    \"username\": \"mikeyk\",\n                    \"full_name\": \"Mikey Krieger\",\n                    \"id\": \"4\",\n                    \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg\"\n                },\n                \"id\": \"8\"\n            },\n            {\n                \"created_time\": \"1279341004\",\n                \"text\": \"Chilako taco\",\n                \"from\": {\n                    \"username\": \"kevin\",\n                    \"full_name\": \"Kevin S\",\n                    \"id\": \"3\",\n                    \"profile_picture\": \"...\"\n                },\n                \"id\": \"3\"\n            }],\n            \"count\": 2\n        },\n        \"caption\": {\n            \"created_time\": \"1296710352\",\n            \"text\": \"Inside le truc #foodtruck\",\n            \"from\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin Systrom\",\n                \"type\": \"user\",\n                \"id\": \"3\"\n            },\n            \"id\": \"26621408\"\n        },\n        \"likes\": {\n            \"count\": 1,\n            \"data\": [{\n                \"username\": \"mikeyk\",\n                \"full_name\": \"Mikeyk\",\n                \"id\": \"4\",\n                \"profile_picture\": \"...\"\n            }]\n        },\n        \"link\": \"http://instagr.am/p/D/\",\n        \"created_time\": \"1279340983\",\n        \"images\": {\n            \"low_resolution\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_6.jpg\",\n                \"width\": 306,\n                \"height\": 306\n            },\n            \"thumbnail\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_5.jpg\",\n                \"width\": 150,\n                \"height\": 150\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_7.jpg\",\n                \"width\": 612,\n                \"height\": 612\n            }\n        },\n        \"type\": \"video\",\n        \"users_in_photo\": [],\n        \"filter\": \"Vesper\",\n        \"tags\": [],\n        \"id\": \"363839373298\",\n        \"user\": {\n            \"username\": \"kevin\",\n            \"full_name\": \"Kevin S\",\n            \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg\",\n            \"id\": \"3\"\n        },\n            \"location\": {\n                \"id\": \"833\",\n                \"latitude\": 37.77956816727314,\n                \"longitude\": -122.41387367248539,\n                \"street_address\": \"\",\n                \"name\": \"Civic Center BART\"\n            }\n    }}]\n}\n",
                               "strict": true,
                               "name": null,
                               "structuredValue": {
@@ -7259,7 +6297,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": 1,
+                          "value": "1",
                           "strict": true,
                           "name": null,
                           "structuredValue": 1
@@ -7350,31 +6388,7 @@
                               }
                             },
                             "structuredExample": {
-                              "value": {
-                                "data": [
-                                  {
-                                    "username": "jack",
-                                    "first_name": "Jack",
-                                    "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_66_75sq.jpg",
-                                    "id": "66",
-                                    "last_name": "Dorsey"
-                                  },
-                                  {
-                                    "username": "sammyjack",
-                                    "first_name": "Sammy",
-                                    "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_29648_75sq_1294520029.jpg",
-                                    "id": "29648",
-                                    "last_name": "Jack"
-                                  },
-                                  {
-                                    "username": "jacktiddy",
-                                    "first_name": "Jack",
-                                    "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_13096_75sq_1286441317.jpg",
-                                    "id": "13096",
-                                    "last_name": "Tiddy"
-                                  }
-                                ]
-                              },
+                              "value": "{\n    \"data\": [{\n        \"username\": \"jack\",\n        \"first_name\": \"Jack\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_66_75sq.jpg\",\n        \"id\": \"66\",\n        \"last_name\": \"Dorsey\"\n    },\n    {\n        \"username\": \"sammyjack\",\n        \"first_name\": \"Sammy\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_29648_75sq_1294520029.jpg\",\n        \"id\": \"29648\",\n        \"last_name\": \"Jack\"\n    },\n    {\n        \"username\": \"jacktiddy\",\n        \"first_name\": \"Jack\",\n        \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_13096_75sq_1286441317.jpg\",\n        \"id\": \"13096\",\n        \"last_name\": \"Tiddy\"\n    }]\n}",
                               "strict": true,
                               "name": null,
                               "structuredValue": {
@@ -7492,7 +6506,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": 100,
+                          "value": "100",
                           "strict": true,
                           "name": null,
                           "structuredValue": 100
@@ -7522,7 +6536,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": 1,
+                          "value": "1",
                           "strict": true,
                           "name": null,
                           "structuredValue": 1
@@ -7773,191 +6787,7 @@
                               }
                             },
                             "structuredExample": {
-                              "value": {
-                                "data": [
-                                  {
-                                    "distance": 50,
-                                    "location": {
-                                      "id": "833",
-                                      "latitude": 37.77956816727314,
-                                      "longitude": -122.4138736724854,
-                                      "street_address": "",
-                                      "name": "Civic Center BART"
-                                    },
-                                    "comments": {
-                                      "count": 16,
-                                      "data": []
-                                    },
-                                    "caption": {
-                                      "created_time": "1296710352",
-                                      "text": "Inside le truc #foodtruck",
-                                      "from": {
-                                        "username": "kevin",
-                                        "full_name": "Kevin Systrom",
-                                        "type": "user",
-                                        "id": "3"
-                                      },
-                                      "id": "26621408"
-                                    },
-                                    "link": "http://instagr.am/p/BXsFz/",
-                                    "likes": {
-                                      "count": 190,
-                                      "data": [
-                                        {
-                                          "username": "shayne",
-                                          "full_name": "Shayne Sweeney",
-                                          "id": "20",
-                                          "profile_picture": "..."
-                                        },
-                                        {}
-                                      ]
-                                    },
-                                    "created_time": "1296748524",
-                                    "images": {
-                                      "low_resolution": {
-                                        "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_6.jpg",
-                                        "width": 306,
-                                        "height": 306
-                                      },
-                                      "thumbnail": {
-                                        "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_5.jpg",
-                                        "width": 150,
-                                        "height": 150
-                                      },
-                                      "standard_resolution": {
-                                        "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_7.jpg",
-                                        "width": 612,
-                                        "height": 612
-                                      }
-                                    },
-                                    "type": "image",
-                                    "users_in_photo": [
-                                      {
-                                        "user": {
-                                          "username": "kevin",
-                                          "full_name": "Kevin S",
-                                          "id": "3",
-                                          "profile_picture": "..."
-                                        },
-                                        "position": {
-                                          "x": 0.315,
-                                          "y": 0.9111
-                                        }
-                                      }
-                                    ],
-                                    "filter": "Earlybird",
-                                    "tags": [],
-                                    "id": "22987123",
-                                    "user": {
-                                      "username": "kevin",
-                                      "full_name": "Kevin S",
-                                      "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
-                                      "id": "3"
-                                    }
-                                  },
-                                  {
-                                    "distance": 50,
-                                    "videos": {
-                                      "low_resolution": {
-                                        "url": "http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_102.mp4",
-                                        "width": 480,
-                                        "height": 480
-                                      },
-                                      "standard_resolution": {
-                                        "url": "http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_101.mp4",
-                                        "width": 640,
-                                        "height": 640
-                                      },
-                                      "comments": {
-                                        "data": [
-                                          {
-                                            "created_time": "1279332030",
-                                            "text": "Love the sign here",
-                                            "from": {
-                                              "username": "mikeyk",
-                                              "full_name": "Mikey Krieger",
-                                              "id": "4",
-                                              "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg"
-                                            },
-                                            "id": "8"
-                                          },
-                                          {
-                                            "created_time": "1279341004",
-                                            "text": "Chilako taco",
-                                            "from": {
-                                              "username": "kevin",
-                                              "full_name": "Kevin S",
-                                              "id": "3",
-                                              "profile_picture": "..."
-                                            },
-                                            "id": "3"
-                                          }
-                                        ],
-                                        "count": 2
-                                      },
-                                      "caption": {
-                                        "created_time": "1296710352",
-                                        "text": "Inside le truc #foodtruck",
-                                        "from": {
-                                          "username": "kevin",
-                                          "full_name": "Kevin Systrom",
-                                          "type": "user",
-                                          "id": "3"
-                                        },
-                                        "id": "26621408"
-                                      },
-                                      "likes": {
-                                        "count": 1,
-                                        "data": [
-                                          {
-                                            "username": "mikeyk",
-                                            "full_name": "Mikeyk",
-                                            "id": "4",
-                                            "profile_picture": "..."
-                                          }
-                                        ]
-                                      },
-                                      "link": "http://instagr.am/p/D/",
-                                      "created_time": "1279340983",
-                                      "images": {
-                                        "low_resolution": {
-                                          "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_6.jpg",
-                                          "width": 306,
-                                          "height": 306
-                                        },
-                                        "thumbnail": {
-                                          "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_5.jpg",
-                                          "width": 150,
-                                          "height": 150
-                                        },
-                                        "standard_resolution": {
-                                          "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_7.jpg",
-                                          "width": 612,
-                                          "height": 612
-                                        }
-                                      },
-                                      "type": "video",
-                                      "users_in_photo": [],
-                                      "filter": "Vesper",
-                                      "tags": [],
-                                      "id": "363839373298",
-                                      "user": {
-                                        "username": "kevin",
-                                        "full_name": "Kevin S",
-                                        "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
-                                        "id": "3"
-                                      },
-                                      "location": {
-                                        "id": "833",
-                                        "latitude": 37.77956816727314,
-                                        "longitude": -122.4138736724854,
-                                        "street_address": "",
-                                        "name": "Civic Center BART"
-                                      }
-                                    }
-                                  }
-                                ]
-                              },
+                              "value": "{\n    \"data\": [{\n        \"distance\" : 50,\n        \"location\": {\n            \"id\": \"833\",\n            \"latitude\": 37.77956816727314,\n            \"longitude\": -122.41387367248539,\n            \"street_address\": \"\",\n            \"name\": \"Civic Center BART\"\n        },\n        \"comments\": {\n            \"count\": 16,\n            \"data\": [  ]\n        },\n        \"caption\":  {\n            \"created_time\": \"1296710352\",\n            \"text\": \"Inside le truc #foodtruck\",\n            \"from\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin Systrom\",\n                \"type\": \"user\",\n                \"id\": \"3\"\n            },\n            \"id\": \"26621408\"\n        },\n        \"link\": \"http://instagr.am/p/BXsFz/\",\n        \"likes\": {\n            \"count\": 190,\n            \"data\": [{\n                \"username\": \"shayne\",\n                \"full_name\": \"Shayne Sweeney\",\n                \"id\": \"20\",\n                \"profile_picture\": \"...\"\n            }, {}]\n        },\n        \"created_time\": \"1296748524\",\n        \"images\": {\n            \"low_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_6.jpg\",\n                \"width\": 306,\n                \"height\": 306\n            },\n            \"thumbnail\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_5.jpg\",\n                \"width\": 150,\n                \"height\": 150\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_7.jpg\",\n                \"width\": 612,\n                \"height\": 612\n            }\n        },\n        \"type\": \"image\",\n        \"users_in_photo\": [{\n            \"user\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin S\",\n                \"id\": \"3\",\n                \"profile_picture\": \"...\"\n            },\n            \"position\": {\n                \"x\": 0.315,\n                \"y\": 0.9111\n            }\n        }],\n        \"filter\": \"Earlybird\",\n        \"tags\": [],\n        \"id\": \"22987123\",\n        \"user\": {\n            \"username\": \"kevin\",\n            \"full_name\": \"Kevin S\",\n            \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg\",\n            \"id\": \"3\"\n        }\n    },\n    {\n        \"distance\" : 50,\n        \"videos\": {\n            \"low_resolution\": {\n                \"url\": \"http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_102.mp4\",\n                \"width\": 480,\n                \"height\": 480\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_101.mp4\",\n                \"width\": 640,\n                \"height\": 640\n            },\n        \"comments\": {\n            \"data\": [{\n                \"created_time\": \"1279332030\",\n                \"text\": \"Love the sign here\",\n                \"from\": {\n                    \"username\": \"mikeyk\",\n                    \"full_name\": \"Mikey Krieger\",\n                    \"id\": \"4\",\n                    \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg\"\n                },\n                \"id\": \"8\"\n            },\n            {\n                \"created_time\": \"1279341004\",\n                \"text\": \"Chilako taco\",\n                \"from\": {\n                    \"username\": \"kevin\",\n                    \"full_name\": \"Kevin S\",\n                    \"id\": \"3\",\n                    \"profile_picture\": \"...\"\n                },\n                \"id\": \"3\"\n            }],\n            \"count\": 2\n        },\n        \"caption\": {\n            \"created_time\": \"1296710352\",\n            \"text\": \"Inside le truc #foodtruck\",\n            \"from\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin Systrom\",\n                \"type\": \"user\",\n                \"id\": \"3\"\n            },\n            \"id\": \"26621408\"\n        },\n        \"likes\": {\n            \"count\": 1,\n            \"data\": [{\n                \"username\": \"mikeyk\",\n                \"full_name\": \"Mikeyk\",\n                \"id\": \"4\",\n                \"profile_picture\": \"...\"\n            }]\n        },\n        \"link\": \"http://instagr.am/p/D/\",\n        \"created_time\": \"1279340983\",\n        \"images\": {\n            \"low_resolution\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_6.jpg\",\n                \"width\": 306,\n                \"height\": 306\n            },\n            \"thumbnail\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_5.jpg\",\n                \"width\": 150,\n                \"height\": 150\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_7.jpg\",\n                \"width\": 612,\n                \"height\": 612\n            }\n        },\n        \"type\": \"video\",\n        \"users_in_photo\": [],\n        \"filter\": \"Vesper\",\n        \"tags\": [],\n        \"id\": \"363839373298\",\n        \"user\": {\n            \"username\": \"kevin\",\n            \"full_name\": \"Kevin S\",\n            \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg\",\n            \"id\": \"3\"\n        },\n            \"location\": {\n                \"id\": \"833\",\n                \"latitude\": 37.77956816727314,\n                \"longitude\": -122.41387367248539,\n                \"street_address\": \"\",\n                \"name\": \"Civic Center BART\"\n            }\n    }}]\n}\n",
                               "strict": true,
                               "name": null,
                               "structuredValue": {
@@ -8264,7 +7094,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": 1,
+                      "value": "1",
                       "strict": true,
                       "name": null,
                       "structuredValue": 1
@@ -8514,7 +7344,7 @@
                           }
                         },
                         "structuredExample": {
-                          "value": 1,
+                          "value": "1",
                           "strict": true,
                           "name": null,
                           "structuredValue": 1
@@ -8765,191 +7595,7 @@
                               }
                             },
                             "structuredExample": {
-                              "value": {
-                                "data": [
-                                  {
-                                    "distance": 50,
-                                    "location": {
-                                      "id": "833",
-                                      "latitude": 37.77956816727314,
-                                      "longitude": -122.4138736724854,
-                                      "street_address": "",
-                                      "name": "Civic Center BART"
-                                    },
-                                    "comments": {
-                                      "count": 16,
-                                      "data": []
-                                    },
-                                    "caption": {
-                                      "created_time": "1296710352",
-                                      "text": "Inside le truc #foodtruck",
-                                      "from": {
-                                        "username": "kevin",
-                                        "full_name": "Kevin Systrom",
-                                        "type": "user",
-                                        "id": "3"
-                                      },
-                                      "id": "26621408"
-                                    },
-                                    "link": "http://instagr.am/p/BXsFz/",
-                                    "likes": {
-                                      "count": 190,
-                                      "data": [
-                                        {
-                                          "username": "shayne",
-                                          "full_name": "Shayne Sweeney",
-                                          "id": "20",
-                                          "profile_picture": "..."
-                                        },
-                                        {}
-                                      ]
-                                    },
-                                    "created_time": "1296748524",
-                                    "images": {
-                                      "low_resolution": {
-                                        "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_6.jpg",
-                                        "width": 306,
-                                        "height": 306
-                                      },
-                                      "thumbnail": {
-                                        "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_5.jpg",
-                                        "width": 150,
-                                        "height": 150
-                                      },
-                                      "standard_resolution": {
-                                        "url": "http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_7.jpg",
-                                        "width": 612,
-                                        "height": 612
-                                      }
-                                    },
-                                    "type": "image",
-                                    "users_in_photo": [
-                                      {
-                                        "user": {
-                                          "username": "kevin",
-                                          "full_name": "Kevin S",
-                                          "id": "3",
-                                          "profile_picture": "..."
-                                        },
-                                        "position": {
-                                          "x": 0.315,
-                                          "y": 0.9111
-                                        }
-                                      }
-                                    ],
-                                    "filter": "Earlybird",
-                                    "tags": [],
-                                    "id": "22987123",
-                                    "user": {
-                                      "username": "kevin",
-                                      "full_name": "Kevin S",
-                                      "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
-                                      "id": "3"
-                                    }
-                                  },
-                                  {
-                                    "distance": 50,
-                                    "videos": {
-                                      "low_resolution": {
-                                        "url": "http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_102.mp4",
-                                        "width": 480,
-                                        "height": 480
-                                      },
-                                      "standard_resolution": {
-                                        "url": "http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_101.mp4",
-                                        "width": 640,
-                                        "height": 640
-                                      },
-                                      "comments": {
-                                        "data": [
-                                          {
-                                            "created_time": "1279332030",
-                                            "text": "Love the sign here",
-                                            "from": {
-                                              "username": "mikeyk",
-                                              "full_name": "Mikey Krieger",
-                                              "id": "4",
-                                              "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg"
-                                            },
-                                            "id": "8"
-                                          },
-                                          {
-                                            "created_time": "1279341004",
-                                            "text": "Chilako taco",
-                                            "from": {
-                                              "username": "kevin",
-                                              "full_name": "Kevin S",
-                                              "id": "3",
-                                              "profile_picture": "..."
-                                            },
-                                            "id": "3"
-                                          }
-                                        ],
-                                        "count": 2
-                                      },
-                                      "caption": {
-                                        "created_time": "1296710352",
-                                        "text": "Inside le truc #foodtruck",
-                                        "from": {
-                                          "username": "kevin",
-                                          "full_name": "Kevin Systrom",
-                                          "type": "user",
-                                          "id": "3"
-                                        },
-                                        "id": "26621408"
-                                      },
-                                      "likes": {
-                                        "count": 1,
-                                        "data": [
-                                          {
-                                            "username": "mikeyk",
-                                            "full_name": "Mikeyk",
-                                            "id": "4",
-                                            "profile_picture": "..."
-                                          }
-                                        ]
-                                      },
-                                      "link": "http://instagr.am/p/D/",
-                                      "created_time": "1279340983",
-                                      "images": {
-                                        "low_resolution": {
-                                          "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_6.jpg",
-                                          "width": 306,
-                                          "height": 306
-                                        },
-                                        "thumbnail": {
-                                          "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_5.jpg",
-                                          "width": 150,
-                                          "height": 150
-                                        },
-                                        "standard_resolution": {
-                                          "url": "http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_7.jpg",
-                                          "width": 612,
-                                          "height": 612
-                                        }
-                                      },
-                                      "type": "video",
-                                      "users_in_photo": [],
-                                      "filter": "Vesper",
-                                      "tags": [],
-                                      "id": "363839373298",
-                                      "user": {
-                                        "username": "kevin",
-                                        "full_name": "Kevin S",
-                                        "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg",
-                                        "id": "3"
-                                      },
-                                      "location": {
-                                        "id": "833",
-                                        "latitude": 37.77956816727314,
-                                        "longitude": -122.4138736724854,
-                                        "street_address": "",
-                                        "name": "Civic Center BART"
-                                      }
-                                    }
-                                  }
-                                ]
-                              },
+                              "value": "{\n    \"data\": [{\n        \"distance\" : 50,\n        \"location\": {\n            \"id\": \"833\",\n            \"latitude\": 37.77956816727314,\n            \"longitude\": -122.41387367248539,\n            \"street_address\": \"\",\n            \"name\": \"Civic Center BART\"\n        },\n        \"comments\": {\n            \"count\": 16,\n            \"data\": [  ]\n        },\n        \"caption\":  {\n            \"created_time\": \"1296710352\",\n            \"text\": \"Inside le truc #foodtruck\",\n            \"from\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin Systrom\",\n                \"type\": \"user\",\n                \"id\": \"3\"\n            },\n            \"id\": \"26621408\"\n        },\n        \"link\": \"http://instagr.am/p/BXsFz/\",\n        \"likes\": {\n            \"count\": 190,\n            \"data\": [{\n                \"username\": \"shayne\",\n                \"full_name\": \"Shayne Sweeney\",\n                \"id\": \"20\",\n                \"profile_picture\": \"...\"\n            }, {}]\n        },\n        \"created_time\": \"1296748524\",\n        \"images\": {\n            \"low_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_6.jpg\",\n                \"width\": 306,\n                \"height\": 306\n            },\n            \"thumbnail\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_5.jpg\",\n                \"width\": 150,\n                \"height\": 150\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distillery.s3.amazonaws.com/media/2011/02/03/efc502667a554329b52d9a6bab35b24a_7.jpg\",\n                \"width\": 612,\n                \"height\": 612\n            }\n        },\n        \"type\": \"image\",\n        \"users_in_photo\": [{\n            \"user\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin S\",\n                \"id\": \"3\",\n                \"profile_picture\": \"...\"\n            },\n            \"position\": {\n                \"x\": 0.315,\n                \"y\": 0.9111\n            }\n        }],\n        \"filter\": \"Earlybird\",\n        \"tags\": [],\n        \"id\": \"22987123\",\n        \"user\": {\n            \"username\": \"kevin\",\n            \"full_name\": \"Kevin S\",\n            \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg\",\n            \"id\": \"3\"\n        }\n    },\n    {\n        \"distance\" : 50,\n        \"videos\": {\n            \"low_resolution\": {\n                \"url\": \"http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_102.mp4\",\n                \"width\": 480,\n                \"height\": 480\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_101.mp4\",\n                \"width\": 640,\n                \"height\": 640\n            },\n        \"comments\": {\n            \"data\": [{\n                \"created_time\": \"1279332030\",\n                \"text\": \"Love the sign here\",\n                \"from\": {\n                    \"username\": \"mikeyk\",\n                    \"full_name\": \"Mikey Krieger\",\n                    \"id\": \"4\",\n                    \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_1242695_75sq_1293915800.jpg\"\n                },\n                \"id\": \"8\"\n            },\n            {\n                \"created_time\": \"1279341004\",\n                \"text\": \"Chilako taco\",\n                \"from\": {\n                    \"username\": \"kevin\",\n                    \"full_name\": \"Kevin S\",\n                    \"id\": \"3\",\n                    \"profile_picture\": \"...\"\n                },\n                \"id\": \"3\"\n            }],\n            \"count\": 2\n        },\n        \"caption\": {\n            \"created_time\": \"1296710352\",\n            \"text\": \"Inside le truc #foodtruck\",\n            \"from\": {\n                \"username\": \"kevin\",\n                \"full_name\": \"Kevin Systrom\",\n                \"type\": \"user\",\n                \"id\": \"3\"\n            },\n            \"id\": \"26621408\"\n        },\n        \"likes\": {\n            \"count\": 1,\n            \"data\": [{\n                \"username\": \"mikeyk\",\n                \"full_name\": \"Mikeyk\",\n                \"id\": \"4\",\n                \"profile_picture\": \"...\"\n            }]\n        },\n        \"link\": \"http://instagr.am/p/D/\",\n        \"created_time\": \"1279340983\",\n        \"images\": {\n            \"low_resolution\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_6.jpg\",\n                \"width\": 306,\n                \"height\": 306\n            },\n            \"thumbnail\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_5.jpg\",\n                \"width\": 150,\n                \"height\": 150\n            },\n            \"standard_resolution\": {\n                \"url\": \"http://distilleryimage2.ak.instagram.com/11f75f1cd9cc11e2a0fd22000aa8039a_7.jpg\",\n                \"width\": 612,\n                \"height\": 612\n            }\n        },\n        \"type\": \"video\",\n        \"users_in_photo\": [],\n        \"filter\": \"Vesper\",\n        \"tags\": [],\n        \"id\": \"363839373298\",\n        \"user\": {\n            \"username\": \"kevin\",\n            \"full_name\": \"Kevin S\",\n            \"profile_picture\": \"http://distillery.s3.amazonaws.com/profiles/profile_3_75sq_1295574122.jpg\",\n            \"id\": \"3\"\n        },\n            \"location\": {\n                \"id\": \"833\",\n                \"latitude\": 37.77956816727314,\n                \"longitude\": -122.41387367248539,\n                \"street_address\": \"\",\n                \"name\": \"Civic Center BART\"\n            }\n    }}]\n}\n",
                               "strict": true,
                               "name": null,
                               "structuredValue": {
@@ -9361,7 +8007,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": 1,
+                      "value": "1",
                       "strict": true,
                       "name": null,
                       "structuredValue": 1
@@ -9548,7 +8194,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": 1,
+                  "value": "1",
                   "strict": true,
                   "name": null,
                   "structuredValue": 1
@@ -9748,7 +8394,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": 1,
+                  "value": "1",
                   "strict": true,
                   "name": null,
                   "structuredValue": 1

--- a/src/raml1/test/data/TCK/RAML10/MethodResponses/test001/methResp01-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/MethodResponses/test001/methResp01-tck.json
@@ -53,9 +53,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "field": "value"
-            },
+            "value": "{\n  \"field\": \"value\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/MethodResponses/test004/methResp04-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/MethodResponses/test004/methResp04-tck.json
@@ -53,9 +53,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "field": "value"
-            },
+            "value": "{\n  \"field\": \"value\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/MethodResponses/test005/methResp05-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/MethodResponses/test005/methResp05-tck.json
@@ -77,9 +77,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "id": "userId"
-            },
+            "value": "{\n  \"id\": \"userId\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -139,10 +137,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "id": "userId",
-              "username": "name"
-            },
+            "value": "{\n  \"id\": \"userId\",\n  \"username\": \"name\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -212,10 +207,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "username": "base",
-                        "id": "any text"
-                      },
+                      "value": "{\n  \"username\": \"base\",\n  \"id\": \"any text\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Methods/test004/meth04-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Methods/test004/meth04-tck.json
@@ -58,7 +58,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": 10,
+                      "value": "10",
                       "strict": true,
                       "name": null,
                       "structuredValue": 10

--- a/src/raml1/test/data/TCK/RAML10/Methods/test009/meth09-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Methods/test009/meth09-tck.json
@@ -53,9 +53,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "field": "value"
-            },
+            "value": "{\n  \"field\": \"value\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Methods/test011/meth11-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Methods/test011/meth11-tck.json
@@ -53,9 +53,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "field": "value"
-            },
+            "value": "{\n  \"field\": \"value\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Methods/test012/meth12-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Methods/test012/meth12-tck.json
@@ -77,9 +77,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "baseField": "name"
-            },
+            "value": "{\n  \"baseField\": \"name\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -139,10 +137,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "baseField": "name",
-              "field": "value"
-            },
+            "value": "{\n  \"baseField\": \"name\",\n  \"field\": \"value\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -212,10 +207,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "baseField": "base",
-                        "field": "any text"
-                      },
+                      "value": "{\n  \"baseField\": \"base\",\n  \"field\": \"any text\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Overlays/test012/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Overlays/test012/api-tck.json
@@ -19,11 +19,7 @@
                     ],
                     "examples": [
                       {
-                        "value": {
-                          "content": {
-                            "name": 7
-                          }
-                        },
+                        "value": "{\n  \"content\": {\n    \"name\": 7\n  }\n}",
                         "strict": true,
                         "name": "test",
                         "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Overlays/test013/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Overlays/test013/api-tck.json
@@ -19,9 +19,7 @@
                     ],
                     "examples": [
                       {
-                        "value": {
-                          "name": 7
-                        },
+                        "value": "{\n  \"name\": 7\n}",
                         "strict": true,
                         "name": "test",
                         "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Overlays/test014/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Overlays/test014/api-tck.json
@@ -19,9 +19,7 @@
                     ],
                     "examples": [
                       {
-                        "value": {
-                          "name": 7
-                        },
+                        "value": "{\n  \"name\": 7\n}",
                         "strict": true,
                         "name": "test",
                         "structuredValue": {
@@ -29,9 +27,7 @@
                         }
                       },
                       {
-                        "value": {
-                          "name": 8
-                        },
+                        "value": "{\n  \"name\": 8\n}",
                         "strict": true,
                         "name": "test2",
                         "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Overlays/test015/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Overlays/test015/api-tck.json
@@ -39,9 +39,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "content": 9
-                      },
+                      "value": "{\n  \"content\": 9\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Overlays/test016/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Overlays/test016/api-tck.json
@@ -39,9 +39,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "content": 9
-                      },
+                      "value": "{\n  \"content\": 9\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test003/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test003/apiInvalid-tck.json
@@ -323,11 +323,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -422,11 +418,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test003/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test003/apiValid-tck.json
@@ -323,11 +323,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -422,11 +418,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test004/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test004/apiInvalid-tck.json
@@ -323,11 +323,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -422,11 +418,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test004/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test004/apiValid-tck.json
@@ -323,11 +323,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue1",
-                    "propertyFromResourceType2": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue1\",\n  \"propertyFromResourceType2\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -422,11 +418,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue1",
-                    "propertyFromResourceType2": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue1\",\n  \"propertyFromResourceType2\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test005/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test005/apiInvalid-tck.json
@@ -323,11 +323,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -422,11 +418,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test005/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test005/apiValid-tck.json
@@ -323,11 +323,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -422,11 +418,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test006/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test006/apiInvalid-tck.json
@@ -323,11 +323,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -422,11 +418,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test006/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test006/apiValid-tck.json
@@ -323,11 +323,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType2": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType2\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -422,11 +418,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType2": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType2\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test007/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test007/apiInvalid-tck.json
@@ -322,10 +322,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -419,11 +416,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "extraProperty1": "stringValue3",
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2"
-                  },
+                  "value": "{\n  \"extraProperty1\": \"stringValue3\",\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test007/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test007/apiValid-tck.json
@@ -322,10 +322,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -419,11 +416,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "extraProperty": "stringValue3",
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2"
-                  },
+                  "value": "{\n  \"extraProperty\": \"stringValue3\",\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test008/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test008/apiInvalid-tck.json
@@ -322,10 +322,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType1": "stringValue1",
-                    "extraProperty": "stringValue2"
-                  },
+                  "value": "{\n  \"propertyFromResourceType1\": \"stringValue1\",\n  \"extraProperty\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -419,11 +416,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue3",
-                    "propertyFromResourceType1": "stringValue1",
-                    "extraProperty": "stringValue2"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue3\",\n  \"propertyFromResourceType1\": \"stringValue1\",\n  \"extraProperty\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test008/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test008/apiValid-tck.json
@@ -322,10 +322,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType1": "stringValue1",
-                    "extraProperty": "stringValue2"
-                  },
+                  "value": "{\n  \"propertyFromResourceType1\": \"stringValue1\",\n  \"extraProperty\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -419,11 +416,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue3",
-                    "propertyFromResourceType1": "stringValue1",
-                    "extraProperty": "stringValue2"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue3\",\n  \"propertyFromResourceType1\": \"stringValue1\",\n  \"extraProperty\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test009/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test009/apiInvalid-tck.json
@@ -322,10 +322,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "extraProperty": "stringValue2"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"extraProperty\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -419,11 +416,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType2": "stringValue3",
-                    "propertyFromType1": "stringValue1",
-                    "extraProperty": "stringValue2"
-                  },
+                  "value": "{\n  \"propertyFromResourceType2\": \"stringValue3\",\n  \"propertyFromType1\": \"stringValue1\",\n  \"extraProperty\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test009/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test009/apiValid-tck.json
@@ -322,10 +322,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "extraProperty": "stringValue2"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"extraProperty\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -419,11 +416,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType1": "stringValue3",
-                    "propertyFromType1": "stringValue1",
-                    "extraProperty": "stringValue2"
-                  },
+                  "value": "{\n  \"propertyFromResourceType1\": \"stringValue3\",\n  \"propertyFromType1\": \"stringValue1\",\n  \"extraProperty\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test010/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test010/apiInvalid-tck.json
@@ -321,9 +321,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "extraProperty": "stringValue1"
-                  },
+                  "value": "{\n  \"extraProperty\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -416,11 +414,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType1": "stringValue2",
-                    "propertyFromType2": "stringValue3",
-                    "extraProperty": "stringValue1"
-                  },
+                  "value": "{\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"propertyFromType2\": \"stringValue3\",\n  \"extraProperty\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test010/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test010/apiValid-tck.json
@@ -321,9 +321,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "extraProperty": "stringValue1"
-                  },
+                  "value": "{\n  \"extraProperty\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -416,11 +414,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType1": "stringValue2",
-                    "propertyFromType1": "stringValue3",
-                    "extraProperty": "stringValue1"
-                  },
+                  "value": "{\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"propertyFromType1\": \"stringValue3\",\n  \"extraProperty\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test011/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test011/apiInvalid-tck.json
@@ -373,11 +373,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType2": "stringValue1",
-                    "propertyFromType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromResourceType2\": \"stringValue1\",\n  \"propertyFromType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test011/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test011/apiValid-tck.json
@@ -373,11 +373,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType1": "stringValue1",
-                    "propertyFromType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromResourceType1\": \"stringValue1\",\n  \"propertyFromType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test003/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test003/apiInvalid-tck.json
@@ -87,10 +87,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "name": "john",
-                        "age": "34s"
-                      },
+                      "value": "{\n  \"name\": \"john\",\n  \"age\": \"34s\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test003/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test003/apiValid-tck.json
@@ -87,10 +87,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "name": "john",
-                        "age": 34
-                      },
+                      "value": "{\n  \"name\": \"john\",\n  \"age\": 34\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test004/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test004/apiInvalid-tck.json
@@ -113,10 +113,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "name": "john",
-                        "age": "34s"
-                      },
+                      "value": "{\n  \"name\": \"john\",\n  \"age\": \"34s\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test004/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test004/apiValid-tck.json
@@ -113,10 +113,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "name": "john",
-                        "age": 34
-                      },
+                      "value": "{\n  \"name\": \"john\",\n  \"age\": 34\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test005/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test005/apiInvalid-tck.json
@@ -84,10 +84,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "name": "john",
-                    "age": "342w"
-                  },
+                  "value": "{\n  \"name\": \"john\",\n  \"age\": \"342w\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test005/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test005/apiValid-tck.json
@@ -87,10 +87,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "name": "john",
-                        "age": 34
-                      },
+                      "value": "{\n  \"name\": \"john\",\n  \"age\": 34\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test006/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test006/apiInvalid-tck.json
@@ -110,10 +110,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "name": "john",
-                    "age": "34s"
-                  },
+                  "value": "{\n  \"name\": \"john\",\n  \"age\": \"34s\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test006/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test006/apiValid-tck.json
@@ -110,10 +110,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "name": "john",
-                    "age": 34
-                  },
+                  "value": "{\n  \"name\": \"john\",\n  \"age\": 34\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test007/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test007/apiInvalid-tck.json
@@ -362,11 +362,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test007/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test007/apiValid-tck.json
@@ -362,11 +362,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test008/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test008/apiInvalid-tck.json
@@ -362,11 +362,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test008/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test008/apiValid-tck.json
@@ -362,11 +362,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue1",
-                    "propertyFromResourceType2": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue1\",\n  \"propertyFromResourceType2\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test009/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test009/apiInvalid-tck.json
@@ -362,11 +362,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test009/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test009/apiValid-tck.json
@@ -362,11 +362,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test010/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test010/apiInvalid-tck.json
@@ -362,11 +362,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test010/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test010/apiValid-tck.json
@@ -362,11 +362,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1",
-                    "propertyFromResourceType2": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\",\n  \"propertyFromResourceType2\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test011/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test011/apiInvalid-tck.json
@@ -162,9 +162,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "extraProperty1": "stringValue1"
-                  },
+                  "value": "{\n  \"extraProperty1\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -375,11 +373,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue2",
-                    "propertyFromResourceType1": "stringValue3",
-                    "extraProperty1": "stringValue1"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue2\",\n  \"propertyFromResourceType1\": \"stringValue3\",\n  \"extraProperty1\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test011/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test011/apiValid-tck.json
@@ -162,9 +162,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "extraProperty": "stringValue1"
-                  },
+                  "value": "{\n  \"extraProperty\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -375,11 +373,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue2",
-                    "propertyFromResourceType1": "stringValue3",
-                    "extraProperty": "stringValue1"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue2\",\n  \"propertyFromResourceType1\": \"stringValue3\",\n  \"extraProperty\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test012/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test012/apiInvalid-tck.json
@@ -162,9 +162,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType2": "stringValue1"
-                  },
+                  "value": "{\n  \"propertyFromType2\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -375,11 +373,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3",
-                    "propertyFromType2": "stringValue1"
-                  },
+                  "value": "{\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\",\n  \"propertyFromType2\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test012/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test012/apiValid-tck.json
@@ -162,9 +162,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue1"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -375,11 +373,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType1": "stringValue2",
-                    "extraProperty": "stringValue3",
-                    "propertyFromType1": "stringValue1"
-                  },
+                  "value": "{\n  \"propertyFromResourceType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\",\n  \"propertyFromType1\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test013/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test013/apiInvalid-tck.json
@@ -162,9 +162,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType2": "stringValue1"
-                  },
+                  "value": "{\n  \"propertyFromResourceType2\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -375,11 +373,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue2",
-                    "extraProperty": "stringValue3",
-                    "propertyFromResourceType2": "stringValue1"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\",\n  \"propertyFromResourceType2\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test013/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test013/apiValid-tck.json
@@ -162,9 +162,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType1": "stringValue1"
-                  },
+                  "value": "{\n  \"propertyFromResourceType1\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -375,11 +373,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromType1": "stringValue2",
-                    "extraProperty": "stringValue3",
-                    "propertyFromResourceType1": "stringValue1"
-                  },
+                  "value": "{\n  \"propertyFromType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\",\n  \"propertyFromResourceType1\": \"stringValue1\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test014/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test014/apiInvalid-tck.json
@@ -163,10 +163,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType1": "stringValue1",
-                    "propertyFromType2": "stringValue2"
-                  },
+                  "value": "{\n  \"propertyFromResourceType1\": \"stringValue1\",\n  \"propertyFromType2\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -378,11 +375,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "extraProperty": "stringValue3",
-                    "propertyFromResourceType1": "stringValue1",
-                    "propertyFromType2": "stringValue2"
-                  },
+                  "value": "{\n  \"extraProperty\": \"stringValue3\",\n  \"propertyFromResourceType1\": \"stringValue1\",\n  \"propertyFromType2\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test014/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test014/apiValid-tck.json
@@ -163,10 +163,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType1": "stringValue1",
-                    "propertyFromType1": "stringValue2"
-                  },
+                  "value": "{\n  \"propertyFromResourceType1\": \"stringValue1\",\n  \"propertyFromType1\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -378,11 +375,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "extraProperty": "stringValue3",
-                    "propertyFromResourceType1": "stringValue1",
-                    "propertyFromType1": "stringValue2"
-                  },
+                  "value": "{\n  \"extraProperty\": \"stringValue3\",\n  \"propertyFromResourceType1\": \"stringValue1\",\n  \"propertyFromType1\": \"stringValue2\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test015/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test015/apiInvalid-tck.json
@@ -164,11 +164,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType2": "stringValue1",
-                    "propertyFromType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromResourceType2\": \"stringValue1\",\n  \"propertyFromType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -381,11 +377,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType2": "stringValue1",
-                    "propertyFromType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromResourceType2\": \"stringValue1\",\n  \"propertyFromType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Resources/test015/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test015/apiValid-tck.json
@@ -164,11 +164,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType1": "stringValue1",
-                    "propertyFromType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromResourceType1\": \"stringValue1\",\n  \"propertyFromType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -381,11 +377,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "propertyFromResourceType1": "stringValue1",
-                    "propertyFromType1": "stringValue2",
-                    "extraProperty": "stringValue3"
-                  },
+                  "value": "{\n  \"propertyFromResourceType1\": \"stringValue1\",\n  \"propertyFromType1\": \"stringValue2\",\n  \"extraProperty\": \"stringValue3\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Responses/test001/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Responses/test001/api-tck.json
@@ -53,9 +53,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "field": "value"
-            },
+            "value": "{\n  \"field\": \"value\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Responses/test004/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Responses/test004/api-tck.json
@@ -53,9 +53,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "field": "value"
-            },
+            "value": "{\n  \"field\": \"value\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Responses/test005/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Responses/test005/api-tck.json
@@ -77,9 +77,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "id": "userId"
-            },
+            "value": "{\n  \"id\": \"userId\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -139,10 +137,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "id": "userId",
-              "username": "name"
-            },
+            "value": "{\n  \"id\": \"userId\",\n  \"username\": \"name\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -212,10 +207,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "username": "base",
-                        "id": "any text"
-                      },
+                      "value": "{\n  \"username\": \"base\",\n  \"id\": \"any text\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Traits/test001/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Traits/test001/apiInvalid-tck.json
@@ -634,9 +634,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "rtTypeProperty2": "stringValue"
-                  },
+                  "value": "{\n  \"rtTypeProperty2\": \"stringValue\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -780,12 +778,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "traitProperty1": true,
-                        "traitProperty2": 1,
-                        "traitProperty1_3": "stringValue1",
-                        "traitProperty2_3": "stringValue2"
-                      },
+                      "value": "{\n  \"traitProperty1\": true,\n  \"traitProperty2\": 1,\n  \"traitProperty1_3\": \"stringValue1\",\n  \"traitProperty2_3\": \"stringValue2\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Traits/test001/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Traits/test001/apiValid-tck.json
@@ -634,9 +634,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "rtTypeProperty1": "stringValue"
-                  },
+                  "value": "{\n  \"rtTypeProperty1\": \"stringValue\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -780,12 +778,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "traitProperty1": true,
-                        "traitProperty2": 1,
-                        "traitProperty1_3": "stringValue1",
-                        "traitProperty2_3": "stringValue2"
-                      },
+                      "value": "{\n  \"traitProperty1\": true,\n  \"traitProperty2\": 1,\n  \"traitProperty1_3\": \"stringValue1\",\n  \"traitProperty2_3\": \"stringValue2\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Traits/test002/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Traits/test002/apiInvalid-tck.json
@@ -634,9 +634,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "rtTypeProperty1": "stringValue"
-                  },
+                  "value": "{\n  \"rtTypeProperty1\": \"stringValue\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -780,12 +778,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "traitProperty1": true,
-                        "traitProperty2": 1,
-                        "traitProperty1_3": "stringValue1",
-                        "traitProperty2_3": "stringValue2"
-                      },
+                      "value": "{\n  \"traitProperty1\": true,\n  \"traitProperty2\": 1,\n  \"traitProperty1_3\": \"stringValue1\",\n  \"traitProperty2_3\": \"stringValue2\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Traits/test002/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Traits/test002/apiValid-tck.json
@@ -634,9 +634,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "rtTypeProperty1": "stringValue"
-                  },
+                  "value": "{\n  \"rtTypeProperty1\": \"stringValue\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -780,12 +778,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "traitProperty1": true,
-                        "traitProperty2": 1,
-                        "traitProperty1_3": "stringValue1",
-                        "traitProperty2_3": "stringValue2"
-                      },
+                      "value": "{\n  \"traitProperty1\": true,\n  \"traitProperty2\": 1,\n  \"traitProperty1_3\": \"stringValue1\",\n  \"traitProperty2_3\": \"stringValue2\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Traits/test003/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Traits/test003/apiInvalid-tck.json
@@ -634,9 +634,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "rtTypeProperty2": "stringValue"
-                  },
+                  "value": "{\n  \"rtTypeProperty2\": \"stringValue\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -780,12 +778,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "traitProperty1": 1,
-                        "traitProperty2": true,
-                        "traitProperty1_3": "stringValue1",
-                        "traitProperty2_3": "stringValue2"
-                      },
+                      "value": "{\n  \"traitProperty1\": 1,\n  \"traitProperty2\": true,\n  \"traitProperty1_3\": \"stringValue1\",\n  \"traitProperty2_3\": \"stringValue2\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Traits/test003/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Traits/test003/apiValid-tck.json
@@ -634,9 +634,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "rtTypeProperty2": "stringValue"
-                  },
+                  "value": "{\n  \"rtTypeProperty2\": \"stringValue\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -780,12 +778,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "traitProperty1": true,
-                        "traitProperty2": 1,
-                        "traitProperty1_3": "stringValue1",
-                        "traitProperty2_3": "stringValue2"
-                      },
+                      "value": "{\n  \"traitProperty1\": true,\n  \"traitProperty2\": 1,\n  \"traitProperty1_3\": \"stringValue1\",\n  \"traitProperty2_3\": \"stringValue2\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Traits/test004/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Traits/test004/apiInvalid-tck.json
@@ -634,9 +634,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "rtTypeProperty2": "stringValue"
-                  },
+                  "value": "{\n  \"rtTypeProperty2\": \"stringValue\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -780,12 +778,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "traitProperty1": true,
-                        "traitProperty2": 1,
-                        "traitProperty1_3": "stringValue1",
-                        "traitProperty2_3": "stringValue2"
-                      },
+                      "value": "{\n  \"traitProperty1\": true,\n  \"traitProperty2\": 1,\n  \"traitProperty1_3\": \"stringValue1\",\n  \"traitProperty2_3\": \"stringValue2\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Traits/test004/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Traits/test004/apiValid-tck.json
@@ -634,9 +634,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "rtTypeProperty2": "stringValue"
-                  },
+                  "value": "{\n  \"rtTypeProperty2\": \"stringValue\"\n}",
                   "strict": true,
                   "name": null,
                   "structuredValue": {
@@ -780,12 +778,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "traitProperty1": 1,
-                        "traitProperty2": true,
-                        "traitProperty1_3": "stringValue1",
-                        "traitProperty2_3": "stringValue2"
-                      },
+                      "value": "{\n  \"traitProperty1\": 1,\n  \"traitProperty2\": true,\n  \"traitProperty1_3\": \"stringValue1\",\n  \"traitProperty2_3\": \"stringValue2\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Traits/test006/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Traits/test006/api-tck.json
@@ -96,9 +96,7 @@
                   }
                 },
                 "structuredExample": {
-                  "value": {
-                    "prop": "value"
-                  },
+                  "value": "{\n  \"prop\": \"value\"\n}\n",
                   "strict": true,
                   "name": null,
                   "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/External Types/test005/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/External Types/test005/api-tck.json
@@ -53,9 +53,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "message": 2
-            },
+            "value": "{\n  \"message\": 2\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -90,9 +88,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "id": "4"
-            },
+            "value": "{\n  \"id\": \"4\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/External Types/test006/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/External Types/test006/api-tck.json
@@ -53,9 +53,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "id": "4"
-            },
+            "value": "{\n  \"id\": \"4\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/External Types/test007/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/External Types/test007/api-tck.json
@@ -80,9 +80,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "c": 4
-            },
+            "value": "{\n  \"c\": 4\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/External Types/test008/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/External Types/test008/api-tck.json
@@ -82,11 +82,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "c": {
-                "i": 2
-              }
-            },
+            "value": "{\n  \"c\": {\n    \"i\": 2\n  }\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/External Types/test009/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/External Types/test009/api-tck.json
@@ -82,11 +82,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "c": {
-                "id": "2"
-              }
-            },
+            "value": "{\n  \"c\": {\n    \"id\": \"2\"\n  }\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test002/oType02-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test002/oType02-tck.json
@@ -76,9 +76,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "initial_comments": "oo"
-            },
+            "value": "{\n  \"initial_comments\": \"oo\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test003/oType03-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test003/oType03-tck.json
@@ -147,13 +147,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "comment_id": 2,
-              "initial_comments": "oo",
-              "user": "Raml",
-              "time_stamp": 1422378528,
-              "created": 1422378528
-            },
+            "value": "{\n  \"comment_id\": 2,\n  \"initial_comments\": \"oo\",\n  \"user\": \"Raml\",\n  \"time_stamp\": 1422378528,\n  \"created\": 1422378528\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test004/oType04-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test004/oType04-tck.json
@@ -142,11 +142,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "initial_comments": "oo",
-              "user": "Raml",
-              "time_stamp": 1422378528
-            },
+            "value": "{\n  \"initial_comments\": \"oo\",\n  \"user\": \"Raml\",\n  \"time_stamp\": 1422378528\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test018/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test018/api-tck.json
@@ -72,9 +72,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "eleo"
-            },
+            "value": "{\n  \"name\": \"eleo\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -90,7 +88,7 @@
     {
       "code": 11,
       "message": "Required property: title?? is missed",
-      "path": "apiInvalid.raml",
+      "path": "api.raml",
       "line": 17,
       "column": 4,
       "position": 470,

--- a/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test019/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test019/api-tck.json
@@ -75,9 +75,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "eleo"
-            },
+            "value": "{\n  \"name\": \"eleo\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test020/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test020/api-tck.json
@@ -98,10 +98,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "firstname": "eleo",
-              "lastname": "ortega"
-            },
+            "value": "{\n  \"firstname\": \"eleo\",\n  \"lastname\": \"ortega\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test021/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test021/api-tck.json
@@ -72,9 +72,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "eleo"
-            },
+            "value": "{\n  \"name\": \"eleo\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test022/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test022/api-tck.json
@@ -73,10 +73,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "eleo",
-              "title??": "Yes, I have a title"
-            },
+            "value": "{\n  \"name\": \"eleo\",\n  \"title??\": \"Yes, I have a title\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/PropertyOverride/test001/test1-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/PropertyOverride/test001/test1-tck.json
@@ -532,7 +532,10 @@
                               }
                             },
                             "structuredExample": {
-                              "value": [
+                              "value": "[\n  {\n    \"id\": \"foo\",\n    \"type\": \"Feature\",\n    \"geometry\": {},\n    \"properties\": {\n      \"acquired\": \"2016-02-28T16:41:41.090Z\",\n      \"vnd_camera_gain\": 5\n    },\n    \"_embeds\": [],\n    \"_links\": {\n      \"licenses\": \"https://api.planet.com/v1/scenes/foo/licenses\"\n    }\n  }\n]",
+                              "strict": true,
+                              "name": null,
+                              "structuredValue": [
                                 {
                                   "id": "foo",
                                   "type": "Feature",
@@ -546,24 +549,7 @@
                                     "licenses": "https://api.planet.com/v1/scenes/foo/licenses"
                                   }
                                 }
-                              ],
-                              "strict": true,
-                              "name": null,
-                              "structuredValue": {
-                                "undefined": {
-                                  "id": "foo",
-                                  "type": "Feature",
-                                  "geometry": {},
-                                  "properties": {
-                                    "acquired": "2016-02-28T16:41:41.090Z",
-                                    "vnd_camera_gain": 5
-                                  },
-                                  "_embeds": [],
-                                  "_links": {
-                                    "licenses": "https://api.planet.com/v1/scenes/foo/licenses"
-                                  }
-                                }
-                              }
+                              ]
                             }
                           }
                         }

--- a/src/raml1/test/data/TCK/RAML10/Types/test001/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test001/apiValid-tck.json
@@ -53,9 +53,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "somestring"
-            },
+            "value": "{\n  \"name\": \"somestring\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test002/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test002/apiInvalid-tck.json
@@ -53,9 +53,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "somestring"
-            },
+            "value": "{\n  \"name\": \"somestring\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -115,10 +113,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name1": "somestring",
-              "age": "stringValue"
-            },
+            "value": "{\n  \"name1\": \"somestring\",\n  \"age\": \"stringValue\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test002/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test002/apiValid-tck.json
@@ -53,9 +53,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "somestring"
-            },
+            "value": "{\n  \"name\": \"somestring\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -115,10 +113,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "somestring",
-              "age": 11
-            },
+            "value": "{\n  \"name\": \"somestring\",\n  \"age\": 11\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test003/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test003/apiInvalid-tck.json
@@ -53,9 +53,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "somestring"
-            },
+            "value": "{\n  \"name\": \"somestring\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -168,12 +166,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "someProperty": {
-                "name": "stringValue",
-                "age": "123s"
-              }
-            },
+            "value": "{\n  \"someProperty\": {\n    \"name\": \"stringValue\",\n    \"age\": \"123s\"\n  }\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test003/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test003/apiValid-tck.json
@@ -53,9 +53,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "name": "somestring"
-            },
+            "value": "{\n  \"name\": \"somestring\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -165,12 +163,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "someProperty": {
-                "name": "stringValue",
-                "age": 123
-              }
-            },
+            "value": "{\n  \"someProperty\": {\n    \"name\": \"stringValue\",\n    \"age\": 123\n  }\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test004/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test004/apiInvalid-tck.json
@@ -30,15 +30,13 @@
             }
           },
           "structuredExample": {
-            "value": [
-              100500,
-              "not number"
-            ],
+            "value": "[\n  100500,\n  \"not number\"\n]",
             "strict": true,
             "name": null,
-            "structuredValue": {
-              "undefined": "not number"
-            }
+            "structuredValue": [
+              100500,
+              "not number"
+            ]
           }
         }
       }

--- a/src/raml1/test/data/TCK/RAML10/Types/test004/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test004/apiValid-tck.json
@@ -30,15 +30,13 @@
             }
           },
           "structuredExample": {
-            "value": [
-              "some string",
-              "another string"
-            ],
+            "value": "[\n  \"some string\",\n  \"another string\"\n]",
             "strict": true,
             "name": null,
-            "structuredValue": {
-              "undefined": "another string"
-            }
+            "structuredValue": [
+              "some string",
+              "another string"
+            ]
           }
         }
       }

--- a/src/raml1/test/data/TCK/RAML10/Types/test005/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test005/apiInvalid-tck.json
@@ -164,21 +164,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "users": [
-                {
-                  "name": "John",
-                  "age": "not number"
-                },
-                {
-                  "name1": "Jane",
-                  "age": 28
-                },
-                {
-                  "name": "Alex"
-                }
-              ]
-            },
+            "value": "{\n  \"users\": [\n    {\n      \"name\": \"John\",\n      \"age\": \"not number\"\n    },\n    {\n      \"name1\": \"Jane\",\n      \"age\": 28\n    },\n    {\n      \"name\": \"Alex\"\n    }\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test005/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test005/apiValid-tck.json
@@ -161,18 +161,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "users": [
-                {
-                  "name": "John",
-                  "age": 23
-                },
-                {
-                  "name": "Jane",
-                  "age": 28
-                }
-              ]
-            },
+            "value": "{\n  \"users\": [\n    {\n      \"name\": \"John\",\n      \"age\": 23\n    },\n    {\n      \"name\": \"Jane\",\n      \"age\": 28\n    }\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test006/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test006/apiInvalid-tck.json
@@ -252,16 +252,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "union1": {
-                "property3": "blahblah",
-                "property2": "blahblah"
-              },
-              "union2": {
-                "property3": "blahblah",
-                "property4": "blahblah"
-              }
-            },
+            "value": "{\n  \"union1\": {\n    \"property3\": \"blahblah\",\n    \"property2\": \"blahblah\"\n  },\n  \"union2\": {\n    \"property3\": \"blahblah\",\n    \"property4\": \"blahblah\"\n  }\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test006/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test006/apiValid-tck.json
@@ -252,16 +252,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "union1": {
-                "property1": "blahblah",
-                "property2": "blahblah"
-              },
-              "union2": {
-                "property3": "blahblah",
-                "property4": "blahblah"
-              }
-            },
+            "value": "{\n  \"union1\": {\n    \"property1\": \"blahblah\",\n    \"property2\": \"blahblah\"\n  },\n  \"union2\": {\n    \"property3\": \"blahblah\",\n    \"property4\": \"blahblah\"\n  }\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test007/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test007/apiInvalid-tck.json
@@ -108,18 +108,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "unionArray1": [
-                "blah",
-                2,
-                3
-              ],
-              "unionArray2": [
-                "blah",
-                "blah",
-                "blah"
-              ]
-            },
+            "value": "{\n  \"unionArray1\": [\n    \"blah\",\n    2,\n    3\n  ],\n  \"unionArray2\": [\n    \"blah\",\n    \"blah\",\n    \"blah\"\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test007/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test007/apiValid-tck.json
@@ -108,18 +108,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "unionArray1": [
-                1,
-                2,
-                3
-              ],
-              "unionArray2": [
-                "blah",
-                "blah",
-                "blah"
-              ]
-            },
+            "value": "{\n  \"unionArray1\": [\n    1,\n    2,\n    3\n  ],\n  \"unionArray2\": [\n    \"blah\",\n    \"blah\",\n    \"blah\"\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test008/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test008/apiInvalid-tck.json
@@ -232,18 +232,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "unionArray": [
-                {
-                  "property1": "val1",
-                  "property4": "val2"
-                },
-                {
-                  "property3": "val3",
-                  "property4": "val4"
-                }
-              ]
-            },
+            "value": "{\n  \"unionArray\": [\n    {\n      \"property1\": \"val1\",\n      \"property4\": \"val2\"\n    },\n    {\n      \"property3\": \"val3\",\n      \"property4\": \"val4\"\n    }\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test008/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test008/apiValid-tck.json
@@ -232,18 +232,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "unionArray": [
-                {
-                  "property1": "val1",
-                  "property2": "val2"
-                },
-                {
-                  "property3": "val3",
-                  "property4": "val4"
-                }
-              ]
-            },
+            "value": "{\n  \"unionArray\": [\n    {\n      \"property1\": \"val1\",\n      \"property2\": \"val2\"\n    },\n    {\n      \"property3\": \"val3\",\n      \"property4\": \"val4\"\n    }\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test009/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test009/apiInvalid-tck.json
@@ -232,18 +232,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "unionArray": [
-                {
-                  "property1": "val1",
-                  "property2": "val2"
-                },
-                {
-                  "property1": "val1",
-                  "property2": 2
-                }
-              ]
-            },
+            "value": "{\n  \"unionArray\": [\n    {\n      \"property1\": \"val1\",\n      \"property2\": \"val2\"\n    },\n    {\n      \"property1\": \"val1\",\n      \"property2\": 2\n    }\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test009/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test009/apiValid-tck.json
@@ -232,18 +232,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "unionArray": [
-                {
-                  "property1": "val1",
-                  "property2": "val2"
-                },
-                {
-                  "property1": 1,
-                  "property2": 2
-                }
-              ]
-            },
+            "value": "{\n  \"unionArray\": [\n    {\n      \"property1\": \"val1\",\n      \"property2\": \"val2\"\n    },\n    {\n      \"property1\": 1,\n      \"property2\": 2\n    }\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test010/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test010/apiValid-tck.json
@@ -132,16 +132,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "prop": [
-                {
-                  "name": "stringValue1"
-                },
-                {
-                  "name": "stringValue2"
-                }
-              ]
-            },
+            "value": "{\n  \"prop\": [\n    {\n      \"name\": \"stringValue1\"\n    },\n    {\n      \"name\": \"stringValue2\"\n    }\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test011/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test011/apiValid-tck.json
@@ -128,12 +128,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "prop": [
-                "val1",
-                "val2"
-              ]
-            },
+            "value": "{\n  \"prop\": [\n    \"val1\",\n    \"val2\"\n  ]\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test012/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test012/apiInvalid-tck.json
@@ -86,20 +86,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "selfReference": [
-                {
-                  "selfReference": [
-                    {
-                      "selfReference": [],
-                      "someProperty1": "val1"
-                    }
-                  ],
-                  "someProperty": "val2"
-                }
-              ],
-              "someProperty": "val3"
-            },
+            "value": "{\n  \"selfReference\": [\n    {\n      \"selfReference\": [\n        {\n          \"selfReference\": [],\n          \"someProperty1\": \"val1\"\n        }\n      ],\n      \"someProperty\": \"val2\"\n    }\n  ],\n  \"someProperty\": \"val3\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test012/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test012/apiValid-tck.json
@@ -86,20 +86,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "selfReference": [
-                {
-                  "selfReference": [
-                    {
-                      "selfReference": [],
-                      "someProperty": "stringValue"
-                    }
-                  ],
-                  "someProperty": "stringValue"
-                }
-              ],
-              "someProperty": "stringValue"
-            },
+            "value": "{\n  \"selfReference\": [\n    {\n      \"selfReference\": [\n        {\n          \"selfReference\": [],\n          \"someProperty\": \"stringValue\"\n        }\n      ],\n      \"someProperty\": \"stringValue\"\n    }\n  ],\n  \"someProperty\": \"stringValue\"\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test013/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test013/apiInvalid-tck.json
@@ -60,13 +60,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "someProperty": {
-                "someProperty": {
-                  "someProperty": "null"
-                }
-              }
-            },
+            "value": "{\n  \"someProperty\": {\n    \"someProperty\": {\n      \"someProperty\": \"null\"\n    }\n  }\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test013/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test013/apiValid-tck.json
@@ -60,13 +60,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "someProperty": {
-                "someProperty": {
-                  "someProperty": "null"
-                }
-              }
-            },
+            "value": "{\n  \"someProperty\": {\n    \"someProperty\": {\n      \"someProperty\": \"null\"\n    }\n  }\n}",
             "strict": true,
             "name": null,
             "structuredValue": {

--- a/src/raml1/test/data/TCK/RAML10/Types/test024/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test024/api-tck.json
@@ -27,7 +27,7 @@
             }
           },
           "structuredExample": {
-            "value": 630128,
+            "value": "630128",
             "strict": true,
             "name": null,
             "structuredValue": 630128
@@ -197,13 +197,7 @@
             }
           },
           "structuredExample": {
-            "value": {
-              "country": "US",
-              "city": "SF",
-              "street": "Geary Street",
-              "house": "77, Suite 400",
-              "zip": 94108
-            },
+            "value": "{\n  \"country\": \"US\",\n  \"city\": \"SF\",\n  \"street\": \"Geary Street\",\n  \"house\": \"77, Suite 400\",\n  \"zip\": 94108\n}\n",
             "strict": true,
             "name": null,
             "structuredValue": {
@@ -296,17 +290,7 @@
           ],
           "examples": [
             {
-              "value": {
-                "id": 11,
-                "name": "John Johnson",
-                "email": "press@mulesoft.com",
-                "phone": "+7-913-111-1111",
-                "address": {
-                  "country": "RUS",
-                  "city": "Novosibirsk",
-                  "zip": 630090
-                }
-              },
+              "value": "{\n  \"id\": 11,\n  \"name\": \"John Johnson\",\n  \"email\": \"press@mulesoft.com\",\n  \"phone\": \"+7-913-111-1111\",\n  \"address\": {\n    \"country\": \"RUS\",\n    \"city\": \"Novosibirsk\",\n    \"zip\": 630090\n  }\n}",
               "strict": true,
               "structuredValue": {
                 "id": 11,
@@ -321,17 +305,7 @@
               }
             },
             {
-              "value": {
-                "id": 12,
-                "name": "John Johnson",
-                "email": "press1@mulesoft.com",
-                "phone": "+1-222-222-2222",
-                "address": {
-                  "country": "US",
-                  "city": "SF",
-                  "zip": 123456
-                }
-              },
+              "value": "{\n  \"id\": 12,\n  \"name\": \"John Johnson\",\n  \"email\": \"press1@mulesoft.com\",\n  \"phone\": \"+1-222-222-2222\",\n  \"address\": {\n    \"country\": \"US\",\n    \"city\": \"SF\",\n    \"zip\": 123456\n  }\n}",
               "strict": true,
               "structuredValue": {
                 "id": 12,
@@ -496,18 +470,7 @@
           ],
           "examples": [
             {
-              "value": {
-                "id": 11,
-                "name": "John Johnson",
-                "email": "press@mulesoft.com",
-                "phone": "+7-913-111-1111",
-                "address": {
-                  "country": "RUS",
-                  "city": "Novosibirsk",
-                  "zip": 630090
-                },
-                "managerId": 77
-              },
+              "value": "{\n  \"id\": 11,\n  \"name\": \"John Johnson\",\n  \"email\": \"press@mulesoft.com\",\n  \"phone\": \"+7-913-111-1111\",\n  \"address\": {\n    \"country\": \"RUS\",\n    \"city\": \"Novosibirsk\",\n    \"zip\": 630090\n  },\n  \"managerId\": 77\n}",
               "strict": true,
               "name": "manager1",
               "structuredValue": {
@@ -524,18 +487,7 @@
               }
             },
             {
-              "value": {
-                "id": 12,
-                "name": "John Johnson",
-                "email": "press1@mulesoft.com",
-                "phone": "+1-222-222-2222",
-                "address": {
-                  "country": "US",
-                  "city": "SF",
-                  "zip": 123456
-                },
-                "managerId": 88
-              },
+              "value": "{\n  \"id\": 12,\n  \"name\": \"John Johnson\",\n  \"email\": \"press1@mulesoft.com\",\n  \"phone\": \"+1-222-222-2222\",\n  \"address\": {\n    \"country\": \"US\",\n    \"city\": \"SF\",\n    \"zip\": 123456\n  },\n  \"managerId\": 88\n}",
               "strict": true,
               "name": "manager2",
               "structuredValue": {

--- a/src/raml1/test/data/vfsTests/jsonRefsTest001/api-tck.json
+++ b/src/raml1/test/data/vfsTests/jsonRefsTest001/api-tck.json
@@ -91,13 +91,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "p1": "p1Value",
-                        "p2": {
-                          "q1": "q1Value",
-                          "q2": 12
-                        }
-                      },
+                      "value": "{\n  \"p1\": \"p1Value\",\n  \"p2\": {\n    \"q1\": \"q1Value\",\n    \"q2\": 12\n  }\n}\n",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/data/vfsTests/ramlRefsTest001/api-tck.json
+++ b/src/raml1/test/data/vfsTests/ramlRefsTest001/api-tck.json
@@ -47,11 +47,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "p1": 1,
-                        "p2": true,
-                        "p3": "stringValue"
-                      },
+                      "value": "{\n  \"p1\": 1,\n  \"p2\": true,\n  \"p3\": \"stringValue\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {
@@ -108,11 +104,7 @@
                       }
                     },
                     "structuredExample": {
-                      "value": {
-                        "p1": 1,
-                        "p2": true,
-                        "p3": "stringValue"
-                      },
+                      "value": "{\n  \"p1\": 1,\n  \"p2\": true,\n  \"p3\": \"stringValue\"\n}",
                       "strict": true,
                       "name": null,
                       "structuredValue": {

--- a/src/raml1/test/examplesApiTests.ts
+++ b/src/raml1/test/examplesApiTests.ts
@@ -16,6 +16,7 @@ import search=require("../ast.core/search")
 import wrapper=require("../artifacts/raml10parser");
 import wrapperApi=require("../artifacts/raml10parserapi");
 import wrapperHelper=require("../wrapped-ast/wrapperHelper");
+import core=require("../wrapped-ast/parserCore");
 import services=require("../definition-system/ramlServices")
 //
 //import t3 = require("../artifacts/raml10parser")
@@ -27,7 +28,7 @@ describe('Example API tests.',function(){
     it ("Direct YAML example",function() {
         var api=<wrapper.ApiImpl>wrapperHelper.load(path.resolve(dir,"data/parser/examples/example_api01.raml"))
         var example = api.types()[0].example();
-        assert.deepEqual(example.value(),{prop1: "value1"});
+        assert.deepEqual((<core.TypeInstanceImpl>example.structuredValue()).toJSON(),{prop1: "value1"});
         assert(example.strict());
         assert.equal(example.name(),null);
         assert.equal(example.displayName(),null);
@@ -38,7 +39,7 @@ describe('Example API tests.',function(){
     it ("Direct JSON example",function() {
         var api=<wrapper.ApiImpl>wrapperHelper.load(path.resolve(dir,"data/parser/examples/example_api02.raml"))
         var example = api.types()[0].example();
-        assert.deepEqual(example.value(),{prop1: "value1"});
+        assert.deepEqual((<core.TypeInstanceImpl>example.structuredValue()).toJSON(),{prop1: "value1"});
         assert(example.strict());
         assert.equal(example.name(),null);
         assert.equal(example.displayName(),null);
@@ -49,7 +50,7 @@ describe('Example API tests.',function(){
     it ("Wrapped simple YAML example",function() {
         var api=<wrapper.ApiImpl>wrapperHelper.load(path.resolve(dir,"data/parser/examples/example_api03.raml"))
         var example = api.types()[0].example();
-        assert.deepEqual(example.value(),{prop1: "value1"});
+        assert.deepEqual((<core.TypeInstanceImpl>example.structuredValue()).toJSON(),{prop1: "value1"});
         assert(example.strict());
         assert.equal(example.name(),null);
         assert.equal(example.displayName(),null);
@@ -60,7 +61,7 @@ describe('Example API tests.',function(){
     it ("Wrapped extended YAML example",function() {
         var api=<wrapper.ApiImpl>wrapperHelper.load(path.resolve(dir,"data/parser/examples/example_api04.raml"))
         var example = api.types()[0].example();
-        assert.deepEqual(example.value(),{prop1: "value1"});
+        assert.deepEqual((<core.TypeInstanceImpl>example.structuredValue()).toJSON(),{prop1: "value1"});
         assert(!example.strict());
         assert.equal(example.name(),null);
         assert.equal(example.displayName(),"myExample");
@@ -80,7 +81,7 @@ describe('Example API tests.',function(){
         var api=<wrapper.ApiImpl>wrapperHelper.load(path.resolve(dir,"data/parser/examples/example_api05.raml"))
 
         var example1 = api.types()[0].examples()[0];
-        assert.deepEqual(example1.value(),{prop1: "value1"});
+        assert.deepEqual((<core.TypeInstanceImpl>example1.structuredValue()).toJSON(),{prop1: "value1"});
         assert(!example1.strict());
         assert.equal(example1.name(),null);
         assert.equal(example1.displayName(),"myExample1");
@@ -96,7 +97,7 @@ describe('Example API tests.',function(){
         assert.equal(aRef11.structuredValue().properties()[0].value().value(),"value1");
 
         var example2 = api.types()[0].examples()[1];
-        assert.deepEqual(example2.value(),{prop1: "value2"});
+        assert.deepEqual((<core.TypeInstanceImpl>example2.structuredValue()).toJSON(),{prop1: "value2"});
         assert(!example2.strict());
         assert.equal(example2.name(),null);
         assert.equal(example2.displayName(),"myExample2");
@@ -116,7 +117,7 @@ describe('Example API tests.',function(){
         var api=<wrapper.ApiImpl>wrapperHelper.load(path.resolve(dir,"data/parser/examples/example_api06.raml"))
 
         var example1 = api.types()[0].examples()[0];
-        assert.deepEqual(example1.value(),{prop1: "value1"});
+        assert.deepEqual((<core.TypeInstanceImpl>example1.structuredValue()).toJSON(),{prop1: "value1"});
         assert(!example1.strict());
         assert.equal(example1.name(),"example1");
         assert.equal(example1.displayName(),"myExample1");
@@ -132,7 +133,7 @@ describe('Example API tests.',function(){
         assert.equal(aRef11.structuredValue().properties()[0].value().value(),"value1");
 
         var example2 = api.types()[0].examples()[1];
-        assert.deepEqual(example2.value(),{prop1: "value2"});
+        assert.deepEqual((<core.TypeInstanceImpl>example2.structuredValue()).toJSON(),{prop1: "value2"});
         assert(!example2.strict());
         assert.equal(example2.name(),"example2");
         assert.equal(example2.displayName(),"myExample2");

--- a/src/raml1/wrapped-ast/wrapperHelper.ts
+++ b/src/raml1/wrapped-ast/wrapperHelper.ts
@@ -1008,14 +1008,17 @@ export class ExampleSpecImpl extends core.BasicNodeImpl{
     }
 
     value():any{
-        if(this.expandable.isJSONString()||this.expandable.isYAML()) {
-            return this.expandable.asJSON();
-        }
-        return this.expandable.original();
+        return this.expandable.asString();
     }
 
     structuredValue():core.TypeInstanceImpl{
-        var obj = this.value();
+        var obj;
+        if(this.expandable.isJSONString()||this.expandable.isYAML()) {
+            obj = this.expandable.asJSON();
+        }
+        else {
+            obj = this.expandable.original();
+        }
         var llParent = this._node.lowLevel();
         var key = this.expandable.isSingle() ? "example" : null;
         var jsonNode = new json.AstNode(llParent.unit(),obj,llParent,null,key);

--- a/src/util/TCKDumper.ts
+++ b/src/util/TCKDumper.ts
@@ -740,7 +740,7 @@ class TypeExampleTransformer implements Transformation{
         arr.forEach(x=>{
             var structuredExample = x['example'];
             if(structuredExample){
-                x['example'] = structuredExample.value;
+                x['example'] = structuredExample.structuredValue;
                 x['structuredExample'] = structuredExample;
             }
         });


### PR DESCRIPTION
The `ExampleSpec.value()` return type is set to string.

The issue:
https://github.com/raml-org/raml-js-parser-2/issues/294

Also fixing:
https://github.com/raml-org/raml-js-parser-2/issues/296
