### PR TITLE
Fixing bugs, updating tck utils, adding tests

### DIFF
--- a/src/raml1/apiLoader.ts
+++ b/src/raml1/apiLoader.ts
@@ -263,7 +263,7 @@ function toApi(unitOrHighlevel:ll.ICompilationUnit|hl.IHighLevelNode, options:pa
 
     var contents = unit.contents();
 
-    var ramlFirstLine = contents.match(/^\s*#%RAML\s+(\d\.\d)\s*(\w*)\s*$/m);
+    var ramlFirstLine = hlimpl.ramlFirstLine(contents);
     if(!ramlFirstLine){
         throw new Error("Invalid first line. A RAML document is expected to start with '#%RAML <version> <?fragment type>'.");
     }

--- a/src/raml1/highLevelImpl.ts
+++ b/src/raml1/highLevelImpl.ts
@@ -1864,34 +1864,11 @@ export class ASTNodeImpl extends BasicASTNode implements  hl.IEditableHighLevelN
 export var universeProvider = require("./definition-system/universeProvider");
 var getDefinitionSystemType = function (contents:string,ast:ll.ILowLevelASTNode) {
 
-
-    var spec = "";
-    var ptype = "Api";
-    var originalPType = null;
-    var num = 0;
-    var pt = 0;
-
-    for (var n = 0; n < contents.length; n++) {
-        var c = contents.charAt(n);
-        if (c == '\r' || c == '\n') {
-            if (spec) {
-                ptype = contents.substring(pt, n).trim();
-                originalPType = ptype;
-            }
-            else {
-                spec = contents.substring(0, n).trim();
-            }
-            break;
-        }
-        if (c == ' ') {
-            num++;
-            if (!spec && num == 2) {
-                spec = contents.substring(0, n);
-                pt = n;
-            }
-        }
-    }
-    var localUniverse = spec == "#%RAML 1.0" ? new def.Universe(null,"RAML10", universeProvider("RAML10"),"RAML10") : new def.Universe(null,"RAML08", universeProvider("RAML08"));
+    var rfl = ramlFirstLine(contents);
+    var spec = (rfl && rfl[1])||"";
+    var ptype = (rfl && rfl.length > 2 && rfl[2]) || "Api";
+    var originalPType = ptype;
+    var localUniverse = spec == "1.0" ? new def.Universe(null,"RAML10", universeProvider("RAML10"),"RAML10") : new def.Universe(null,"RAML08", universeProvider("RAML08"));
 
     if (ptype=='API'){
         ptype="Api"
@@ -1917,6 +1894,10 @@ var getDefinitionSystemType = function (contents:string,ast:ll.ILowLevelASTNode)
     // localUniverse.setDescription(spec);
     return { ptype: ptype, localUniverse: localUniverse };
 };
+
+export function ramlFirstLine(content:string):RegExpMatchArray{
+    return content.match(/^\s*#%RAML\s+(\d\.\d)\s*(\w*)\s*$/m);
+}
 
 export function getFragmentDefenitionName(highLevelNode: hl.IHighLevelNode): string {
     var contents = highLevelNode.lowLevel() && highLevelNode.lowLevel().unit() && highLevelNode.lowLevel().unit().contents();

--- a/src/raml1/test/data/TCK/RAML10/Annotations/test014/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Annotations/test014/apiInvalid-tck.json
@@ -57,7 +57,7 @@
     ],
     "annotationTypes": [
       {
-        "Resource metadata": {
+        "meta": {
           "name": "meta",
           "displayName": "Resource metadata",
           "type": [

--- a/src/raml1/test/data/TCK/RAML10/Annotations/test014/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Annotations/test014/apiValid-tck.json
@@ -57,7 +57,7 @@
     ],
     "annotationTypes": [
       {
-        "Resource metadata": {
+        "meta": {
           "name": "meta",
           "displayName": "Resource metadata",
           "type": [

--- a/src/raml1/test/data/TCK/RAML10/Annotations/test015/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Annotations/test015/apiInvalid-tck.json
@@ -57,7 +57,7 @@
     ],
     "annotationTypes": [
       {
-        "Resource metadata": {
+        "meta": {
           "name": "meta",
           "displayName": "Resource metadata",
           "type": [

--- a/src/raml1/test/data/TCK/RAML10/Annotations/test015/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Annotations/test015/apiValid-tck.json
@@ -57,7 +57,7 @@
     ],
     "annotationTypes": [
       {
-        "Resource metadata": {
+        "meta": {
           "name": "meta",
           "displayName": "Resource metadata",
           "type": [

--- a/src/raml1/test/data/TCK/RAML10/Annotations/test030/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Annotations/test030/api-tck.json
@@ -94,7 +94,7 @@
     ],
     "annotationTypes": [
       {
-        "BindingDefinition": {
+        "bindingDefinition": {
           "name": "bindingDefinition",
           "displayName": "BindingDefinition",
           "type": [

--- a/src/raml1/test/data/TCK/RAML10/Annotations/test032/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Annotations/test032/api-tck.json
@@ -4,7 +4,7 @@
   "specification": {
     "annotationTypes": [
       {
-        "BindingDefinition": {
+        "bindingDefinition": {
           "name": "bindingDefinition",
           "displayName": "BindingDefinition",
           "type": [

--- a/src/raml1/test/data/TCK/RAML10/Api/test030/emptyApi-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Api/test030/emptyApi-tck.json
@@ -1,5 +1,5 @@
 {
-  "ramlVersion": "RAML08",
+  "ramlVersion": "RAML10",
   "type": "Api",
   "specification": {},
   "errors": [

--- a/src/raml1/test/data/TCK/RAML10/Api/test031/emptyApiNewLine-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Api/test031/emptyApiNewLine-tck.json
@@ -6,7 +6,7 @@
     {
       "code": 3,
       "message": "Missing required property title",
-      "path": "emptyApiNewLineLinux.raml",
+      "path": "emptyApiNewLine.raml",
       "line": 1,
       "column": 0,
       "position": 11,

--- a/src/raml1/test/data/TCK/RAML10/Api/test032/emptyApi2NewLine-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Api/test032/emptyApi2NewLine-tck.json
@@ -6,7 +6,7 @@
     {
       "code": 3,
       "message": "Missing required property title",
-      "path": "emptyApiNewLineWin.raml",
+      "path": "emptyApi2NewLine.raml",
       "line": 2,
       "column": 0,
       "position": 12,

--- a/src/raml1/test/data/TCK/RAML10/Examples/test062/lib-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test062/lib-tck.json
@@ -1,0 +1,40 @@
+{
+  "ramlVersion": "RAML10",
+  "type": "Library",
+  "specification": {
+    "types": [
+      {
+        "MyBooleanType": {
+          "name": "MyBooleanType",
+          "displayName": "MyBooleanType",
+          "type": [
+            "boolean"
+          ],
+          "example": false,
+          "repeat": false,
+          "required": true,
+          "__METADATA__": {
+            "primitiveValuesMeta": {
+              "displayName": {
+                "calculated": true
+              },
+              "repeat": {
+                "insertedAsDefault": true
+              },
+              "required": {
+                "insertedAsDefault": true
+              }
+            }
+          },
+          "structuredExample": {
+            "value": "false",
+            "strict": true,
+            "name": null,
+            "structuredValue": false
+          }
+        }
+      }
+    ]
+  },
+  "errors": []
+}

--- a/src/raml1/test/data/TCK/RAML10/Examples/test062/lib.raml
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test062/lib.raml
@@ -1,0 +1,6 @@
+#%RAML 1.0 Library
+
+types:
+  MyBooleanType:
+    type: boolean
+    example: false

--- a/src/raml1/test/scripts/messageMappings.ts
+++ b/src/raml1/test/scripts/messageMappings.ts
@@ -1,8 +1,16 @@
 var mappings = [
-    [
-        "Required property: (.+) is missed",
-        "Missing required field \"(.+)\""
-    ]
+    {
+        messagePatterns: [
+            {
+                "parser": "JS",
+                "pattern": "Required property: (.+) is missed"
+            },
+            {
+                "parser": "Java",
+                "pattern": "Missing required field \"(.+)\""
+            }
+        ]
+    }
 ];
 
 export = mappings;

--- a/src/raml1/test/scripts/tckLauncher.ts
+++ b/src/raml1/test/scripts/tckLauncher.ts
@@ -4,12 +4,16 @@ import tckUtil = require("./tckUtil")
 
 var args = process.argv;
 var dirPath = null;
+var reportPath = null;
 var regenerteJSON = false;
 for(var i = 0 ; i < args.length ; i++){
-    if(args[i]=="-path" && i < args.length-2){
+    if(args[i]=="-path" && i < args.length-1){
         dirPath = args[++i];
     }
-    else if(args[i]=="-generate" && i < args.length-2){
+    else if(args[i]=="-report" && i < args.length-1){
+        reportPath = args[++i];
+    }
+    else if(args[i]=="-generate"){
         regenerteJSON = true;
     }
 }
@@ -17,5 +21,5 @@ if(dirPath == null){
     dirPath = path.resolve(__dirname,"../data/TCK");
 }
 if(dirPath) {
-    tckUtil.launchTests(dirPath,regenerteJSON);
+    tckUtil.launchTests(dirPath,reportPath,regenerteJSON);
 }

--- a/src/util/TCKDumper.ts
+++ b/src/util/TCKDumper.ts
@@ -669,7 +669,7 @@ class AnnotationTypesTransformer extends ArrayToMappingsArrayTransformer{
     constructor(){
         super(new CompositeObjectPropertyMatcher([
             new BasicObjectPropertyMatcher(universeHelpers.isLibraryBaseSibling,universeHelpers.isAnnotationTypesProperty)
-        ]),"displayName");
+        ]),"name");
     }
 
     match(node:coreApi.BasicNode,prop:nominals.IProperty):boolean{


### PR DESCRIPTION
Bug fixed:
https://github.com/raml-org/raml-js-parser-2/issues/303

Switched key annotation appears under from displayName to name, as discussed at
https://github.com/raml-org/raml-js-parser-2/issues/291

Adding test for 'false' as boolean type example

Cleaning TCK utils