### PR TITLE
Fixing tests

### DIFF
--- a/src/raml1/test/data/TCK/RAML10/Examples/test045/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test045/api-tck.json
@@ -44,17 +44,14 @@
               ],
               "examples": [
                 {
-                  "value": "{\n  \"strict\": true,\n  \"content\": [\n    {\n      \"X-Dept\": \"230-OCTO\"\n    }\n  ]\n}",
+                  "value": "[\n  {\n    \"X-Dept\": \"230-OCTO\"\n  }\n]",
                   "strict": true,
                   "name": "one_dept",
-                  "structuredValue": {
-                    "strict": true,
-                    "content": [
-                      {
-                        "X-Dept": "230-OCTO"
-                      }
-                    ]
-                  }
+                  "structuredValue": [
+                    {
+                      "X-Dept": "230-OCTO"
+                    }
+                  ]
                 }
               ],
               "repeat": false,
@@ -83,21 +80,21 @@
   "errors": [
     {
       "code": 11,
-      "message": "array is expected",
+      "message": "string is expected",
       "path": "api.raml",
-      "line": 12,
-      "column": 10,
-      "position": 188,
+      "line": 15,
+      "column": 16,
+      "position": 258,
       "range": [
         {
-          "line": 12,
-          "column": 10,
-          "position": 188
+          "line": 15,
+          "column": 16,
+          "position": 258
         },
         {
-          "line": 12,
-          "column": 18,
-          "position": 196
+          "line": 15,
+          "column": 32,
+          "position": 274
         }
       ]
     }

--- a/src/raml1/test/data/TCK/RAML10/Examples/test045/api.raml
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test045/api.raml
@@ -12,5 +12,5 @@ traits:
         examples:
           one_dept:
             strict: true
-            content:
+            value:
               - X-Dept: 230-OCTO

--- a/src/raml1/test/data/parser/examples/ex9.raml
+++ b/src/raml1/test/data/parser/examples/ex9.raml
@@ -12,5 +12,5 @@ traits:
         examples:
           one_dept:
             strict: true
-            content:
+            value:
               - X-Dept: 230-OCTO

--- a/src/raml1/test/data/parser/overlays/o9/NewOverlay.raml
+++ b/src/raml1/test/data/parser/overlays/o9/NewOverlay.raml
@@ -7,12 +7,12 @@ types:
       secondProp: string
     examples:
       First:
-        content: |
+        value: |
           {
             "firstProp" : "overlayFirstProp",
             "secondProp" : "overlaySecondProp"
           }
       Second:
-        content:
+        value:
           firstProp: "overlayFirstPropYaml"
           secondProp: "overlaySecondPropYaml"

--- a/src/raml1/test/data/parser/overlays/o9/NewOverlay2.raml
+++ b/src/raml1/test/data/parser/overlays/o9/NewOverlay2.raml
@@ -7,12 +7,12 @@ types:
       secondProp: string
     examples:
       First:
-        content: |
+        value: |
           {
             "firstProp" : "overlay2FirstProp",
             "secondProp" : "overlay2SecondProp"
           }
       Second:
-        content:
+        value:
           firstProp: "overlay2FirstPropYaml"
           secondProp: "overlay2SecondPropYaml"

--- a/src/raml1/test/data/parser/typexpressions/ct1.raml
+++ b/src/raml1/test/data/parser/typexpressions/ct1.raml
@@ -17,13 +17,13 @@ types:
       fffaa: s
     examples:
       c:
-        content:
+        value:
           firstName: Pavel
           lastName: Petrochenko
           fffaa: d
           #age: number
       a:
-        content:
+        value:
           firstName: Pavel
           lastName: Denisenko
           age: number

--- a/src/raml1/test/parserTests.ts
+++ b/src/raml1/test/parserTests.ts
@@ -198,7 +198,7 @@ describe('Parser regression tests', function () {
     })
 
     it ("checking that node is actually primitive" ,function(){
-        testErrors(util.data("parser/examples/ex9.raml"), ["array is expected"]);
+        testErrors(util.data("parser/examples/ex9.raml"), ["string is expected"]);
     })
     it ("map" ,function(){
         testErrors(util.data("parser/examples/ex10.raml"));


### PR DESCRIPTION
Fixing those tests, which use ExampleSpec.content instead of ExampleSpec.value

The issue has been discovered at
https://github.com/raml-org/raml-js-parser-2/issues/311