### PR TITLE
Fixing the 1.0 parser behavior related with URI parameters defined by sequences

### DIFF
--- a/src/raml1/ast.core/builder.ts
+++ b/src/raml1/ast.core/builder.ts
@@ -627,10 +627,14 @@ export class BasicNodeBuilder implements hl.INodeBuilder{
                                             return;
                                         }
                                         if (y.valueKind() == yaml.Kind.SEQ) {
+                                            var isRaml1 = aNode.definition().universe().version()=="RAML10"
                                             y.children().forEach(z=> {
                                                 var node = new hlimpl.ASTNodeImpl(z, aNode, <any> range, p);
                                                 node._allowQuestion = allowsQuestion;
                                                 node.setNamePatch(y.key());
+                                                if(isRaml1){
+                                                    (<hlimpl.ASTNodeImpl>node).invalidSequence = true;
+                                                }
                                                 parsed.push(node);
                                             })
                                             if (y.children().length == 0) {

--- a/src/raml1/highLevelAST.ts
+++ b/src/raml1/highLevelAST.ts
@@ -281,6 +281,7 @@ export interface ValidationAcceptor{
     begin()
     accept(issue: ValidationIssue);
     end();
+    acceptUnique(issue: ValidationIssue);
 }
 
 export interface ValidationAction {

--- a/src/raml1/highLevelImpl.ts
+++ b/src/raml1/highLevelImpl.ts
@@ -129,6 +129,7 @@ export class BasicASTNode implements hl.IParseResult {
     knownProperty:hl.IProperty
     needSequence:boolean
     needMap:boolean
+    invalidSequence:boolean
     unresolvedRef:string
     errorMessage: string
 
@@ -164,17 +165,7 @@ export class BasicASTNode implements hl.IParseResult {
 
     errors():hl.ValidationIssue[]{
         var errors:hl.ValidationIssue[]=[];
-        var q:hl.ValidationAcceptor={
-            accept(c:hl.ValidationIssue){
-                errors.push(c);
-            },
-            begin(){
-
-            },
-            end(){
-
-            }
-        }
+        var q = createBasicValidationAcceptor(errors);
         this.validate(q);
         return errors;
     }
@@ -436,19 +427,7 @@ export class ASTPropImpl extends BasicASTNode implements  hl.IAttribute {
 
     errors():hl.ValidationIssue[]{
         var errors:hl.ValidationIssue[]=[];
-        var q:hl.ValidationAcceptor={
-            accept(c:hl.ValidationIssue){
-                if (c.node===this) {
-                    errors.push(c);
-                }
-            },
-            begin(){
-
-            },
-            end(){
-
-            }
-        }
+        var q:hl.ValidationAcceptor= createBasicValidationAcceptor(errors);
         this.parent().validate(q);
         return errors;
     }
@@ -1927,4 +1906,27 @@ export function fromUnit(l: ll.ICompilationUnit): hl.IParseResult {
     //forcing discrimination
     api.children();
     return api;
+}
+
+export function createBasicValidationAcceptor(errors:hl.ValidationIssue[]):hl.ValidationAcceptor{
+    var q:hl.ValidationAcceptor={
+        accept(c:hl.ValidationIssue){
+            errors.push(c);
+        },
+        begin(){
+
+        },
+        end(){
+
+        },
+        acceptUnique(issue: hl.ValidationIssue){
+            for(var e of errors){
+                if(e.start==issue.start && e.message==issue.message){
+                    return;
+                }
+            }
+            this.accept(issue);
+        }
+    }
+    return q;
 }

--- a/src/raml1/test/data/TCK/RAML10/Api/test016/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Api/test016/api-tck.json
@@ -59,5 +59,26 @@
       }
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "code": 2,
+      "message": "In RAML 1.0 base uri parameter is not allowed to have sequence as definition",
+      "path": "api.raml",
+      "line": 4,
+      "column": 2,
+      "position": 74,
+      "range": [
+        {
+          "line": 4,
+          "column": 2,
+          "position": 74
+        },
+        {
+          "line": 4,
+          "column": 3,
+          "position": 75
+        }
+      ]
+    }
+  ]
 }

--- a/src/raml1/test/parserTesting.ts
+++ b/src/raml1/test/parserTesting.ts
@@ -20,6 +20,7 @@ import tools = require("./testTools")
 
 import smg = require("../tools/schemaModelGen");
 import expander = require("../ast.core/expander")
+import hlimpl = require("../highLevelImpl")
 import RamlWrapper = require("../artifacts/raml10parser")
 import json = require("../jsyaml/json2lowLevel")
 import wrapper10=require("../artifacts/raml10parser")
@@ -30,17 +31,7 @@ function testErrorsByNumber(p:string,count:number=0){
     var api=util.loadApi(p);
     api = util.expandHighIfNeeded(api);
     var errors:any=[];
-    var q:hl.ValidationAcceptor={
-        accept(c:any){
-            errors.push(c);
-        },
-        begin(){
-
-        },
-        end(){
-
-        }
-    }
+    var q:hl.ValidationAcceptor= hlimpl.createBasicValidationAcceptor(errors);
     api.validate(q);
     if(errors.length!=count) {
         errors.forEach(error=>console.log(error.message))

--- a/src/raml1/test/parserTests2.ts
+++ b/src/raml1/test/parserTests2.ts
@@ -78,8 +78,8 @@ describe('API parsing', function() {
    });
 
 //  #2030
-   it('Should succeed when dealing with URI parameters with two types', function(){
-       testErrors(util.data('parser/api/api15.raml'));
+   it('RAML 1.0 parser should reject URI parameters declared by sequences', function(){
+       testErrors(util.data('parser/api/api15.raml'),["In RAML 1.0 base uri parameter is not allowed to have sequence as definition"]);
    });
 
     it('Should parse resource description', function(){

--- a/src/raml1/test/test-utils.ts
+++ b/src/raml1/test/test-utils.ts
@@ -337,17 +337,7 @@ ${label1}: ${strValue1}`
 
 export function validateNode(api:hl.IHighLevelNode):hl.ValidationIssue[] {
   var errors:hl.ValidationIssue[] = [];
-  var q:hl.ValidationAcceptor = {
-    accept(c:any) {
-      errors.push(c);
-    },
-    begin() {
-
-    },
-    end() {
-
-    }
-  }
+  var q:hl.ValidationAcceptor = hlimpl.createBasicValidationAcceptor(errors);
   api.validate(q);
   return errors;
 };
@@ -438,18 +428,8 @@ export function testAST(masterPath : string, astPath: string, extensions? : stri
   }
 
   //Validating first. It is supposed that there should be no errors in AST we are testing
-  var errors:ParserError[]=[];
-  var q:hl.ValidationAcceptor={
-    accept(c:ParserError){
-      errors.push(c);
-    },
-    begin(){
-
-    },
-    end(){
-
-    }
-  }
+  var errors:hl.ValidationIssue[]=[];
+  var q:hl.ValidationAcceptor= hlimpl.createBasicValidationAcceptor(errors);
 
   api.validate(q);
 


### PR DESCRIPTION
In RAML 1.0 it is prohibited to define URI parameters by sequences. For example:
```
#%RAML 1.0
title: Test
baseUri: http://{a}.myapi.org
baseUriParameters:
  a:
    - displayName: second
      description: This is A
      type: string
    - displayName: 2
      description: This is A
      type: integer

```

Issue fixed:
https://github.com/raml-org/raml-js-parser-2/issues/307