### PR TITLE
Support for unofficial top-level types in media types

### DIFF
--- a/src/raml1/ast.core/linter.ts
+++ b/src/raml1/ast.core/linter.ts
@@ -1210,20 +1210,9 @@ class MediaTypeValidator implements PropertyValidator{
 
 
             var res = mediaTypeParser.parse(v);
-            var types = {
-                application: 1,
-                audio: 1,
-                example: 1,
-                image: 1,
-                message: 1,
-                model: 1,
-                multipart: 1,
-                text: 1,
-                video: 1,
-                binary: 1
-            }
-            if (!types[res.type]) {
-                cb.accept(createIssue(hl.IssueCode.INVALID_VALUE_SCHEMA, "Unknown media type 'type'", node))
+            //check if type name satisfies RFC6338
+            if (!res.type.match(/[\w\d][\w\d!#\$&\-\^_+\.]*/)) {
+                cb.accept(createIssue(hl.IssueCode.INVALID_VALUE_SCHEMA, `Invalid media type '${res.type}'`, node))
             }
         }catch (e){
             cb.accept(createIssue(hl.IssueCode.INVALID_VALUE_SCHEMA, ""+e.message, node))

--- a/src/raml1/test/data/TCK/RAML10/MethodResponses/test003/methResp03-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/MethodResponses/test003/methResp03-tck.json
@@ -307,26 +307,5 @@
       }
     ]
   },
-  "errors": [
-    {
-      "code": 7,
-      "message": "Unknown media type 'type'",
-      "path": "methResp03.raml",
-      "line": 17,
-      "column": 10,
-      "position": 354,
-      "range": [
-        {
-          "line": 17,
-          "column": 10,
-          "position": 354
-        },
-        {
-          "line": 17,
-          "column": 19,
-          "position": 363
-        }
-      ]
-    }
-  ]
+  "errors": []
 }

--- a/src/raml1/test/data/TCK/RAML10/Methods/test010/meth10-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Methods/test010/meth10-tck.json
@@ -302,26 +302,5 @@
       }
     ]
   },
-  "errors": [
-    {
-      "code": 7,
-      "message": "Unknown media type 'type'",
-      "path": "meth10.raml",
-      "line": 15,
-      "column": 6,
-      "position": 280,
-      "range": [
-        {
-          "line": 15,
-          "column": 6,
-          "position": 280
-        },
-        {
-          "line": 15,
-          "column": 15,
-          "position": 289
-        }
-      ]
-    }
-  ]
+  "errors": []
 }

--- a/src/raml1/test/data/TCK/RAML10/Responses/test003/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Responses/test003/api-tck.json
@@ -307,26 +307,5 @@
       }
     ]
   },
-  "errors": [
-    {
-      "code": 7,
-      "message": "Unknown media type 'type'",
-      "path": "api.raml",
-      "line": 17,
-      "column": 10,
-      "position": 354,
-      "range": [
-        {
-          "line": 17,
-          "column": 10,
-          "position": 354
-        },
-        {
-          "line": 17,
-          "column": 19,
-          "position": 363
-        }
-      ]
-    }
-  ]
+  "errors": []
 }

--- a/src/raml1/test/parserTests2.ts
+++ b/src/raml1/test/parserTests2.ts
@@ -311,8 +311,8 @@ describe('Method', function(){
         testErrors(util.data('parser/method/meth09.raml'));
     });
 
-    it('Check that only reserved mimeTypes are applicable', function(){
-        testErrors(util.data('parser/method/meth10.raml'), ["Unknown media type '\\w+'"]);
+    it('Check that custom mime types are applicable', function(){
+        testErrors(util.data('parser/method/meth10.raml'));
     });
 
     it('Should parse pair \'mimeType:type\'.', function(){
@@ -351,8 +351,8 @@ describe('Method response', function(){
         testErrors(util.data('parser/methodResponse/methResp02.raml'));
     });
 
-    it('Only reserved reserved mimeTypes are applicable', function(){
-        testErrors(util.data('parser/methodResponse/methResp03.raml'), ["Unknown media type '\\w+'"]);
+    it('Custom mime types are applicable', function(){
+        testErrors(util.data('parser/methodResponse/methResp03.raml'));
     });
 
     it('Should allows to set response body with pair \'mimeType:type\'', function(){


### PR DESCRIPTION
Formally, per RFC6838 , top level types are not restricted to ```application, audio, example, image, message, model, multipart, text, video```.

The only restriction on type names is
https://tools.ietf.org/html/rfc6838#section-4.2

fixing
https://github.com/raml-org/raml-js-parser-2/issues/314