### PR TITLE
In Async mode parser must not throw exceptions on unresolved paths.

### DIFF
--- a/src/raml1/jsyaml/jsyaml2lowLevel.ts
+++ b/src/raml1/jsyaml/jsyaml2lowLevel.ts
@@ -940,7 +940,7 @@ export class Project implements lowlevel.IProject{
         if(absolute||lowlevel.isWebPath(p)){
             if(this.failedUnits[p]!=null){
                 if (!this.failedUnits[p].inner) {
-                    throw(this.failedUnits[p]);
+                    return null;//throw(this.failedUnits[p]);
                 }
             }
         }
@@ -948,7 +948,7 @@ export class Project implements lowlevel.IProject{
             var ap = lowlevel.toAbsolutePath(this.rootPath,p);
             if(this.failedUnits[ap]){
                 if (!this.failedUnits[p].inner) {
-                    throw(this.failedUnits[p]);
+                    return null;//throw(this.failedUnits[p]);
                 }
             }
         }


### PR DESCRIPTION
Fixing https://github.com/raml-org/raml-js-parser-2/issues/344