### PR TITLE
Fixing spelling in those error messages, which use "then" instead of "than"

### DIFF
--- a/src/raml1/test/data/TCK/RAML10/Annotations/test015/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Annotations/test015/apiInvalid-tck.json
@@ -110,7 +110,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "string length should be not less then 10",
+      "message": "string length should be not less than 10",
       "path": "apiInvalid.raml",
       "line": 16,
       "column": 2,

--- a/src/raml1/test/data/TCK/RAML10/Annotations/test024/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Annotations/test024/apiInvalid-tck.json
@@ -42,7 +42,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "value should be not less then 2",
+      "message": "value should be not less than 2",
       "path": "apiInvalid.raml",
       "line": 7,
       "column": 2,

--- a/src/raml1/test/data/TCK/RAML10/Annotations/test025/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Annotations/test025/apiInvalid-tck.json
@@ -42,7 +42,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "value should be not more then 10",
+      "message": "value should be not more than 10",
       "path": "apiInvalid.raml",
       "line": 7,
       "column": 2,

--- a/src/raml1/test/data/TCK/RAML10/Examples/test008/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test008/api-tck.json
@@ -148,7 +148,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "array should have not less then 5 items",
+      "message": "array should have not less than 5 items",
       "path": "api.raml",
       "line": 15,
       "column": 6,
@@ -168,7 +168,7 @@
     },
     {
       "code": 11,
-      "message": "array should have not more then 3 items",
+      "message": "array should have not more than 3 items",
       "path": "api.raml",
       "line": 16,
       "column": 6,

--- a/src/raml1/test/data/TCK/RAML10/Examples/test010/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test010/api-tck.json
@@ -104,7 +104,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "array should have not less then 5 items",
+      "message": "array should have not less than 5 items",
       "path": "api.raml",
       "line": 11,
       "column": 6,

--- a/src/raml1/test/data/TCK/RAML10/Examples/test011/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test011/api-tck.json
@@ -131,7 +131,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "array should have not less then 5 items",
+      "message": "array should have not less than 5 items",
       "path": "api.raml",
       "line": 12,
       "column": 10,

--- a/src/raml1/test/data/TCK/RAML10/Examples/test013/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test013/api-tck.json
@@ -71,7 +71,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "object should have not less then 2 properties",
+      "message": "object should have not less than 2 properties",
       "path": "api.raml",
       "line": 7,
       "column": 4,

--- a/src/raml1/test/data/TCK/RAML10/Examples/test014/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test014/api-tck.json
@@ -109,7 +109,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "object should have not less then 2 properties",
+      "message": "object should have not less than 2 properties",
       "path": "api.raml",
       "line": 12,
       "column": 4,

--- a/src/raml1/test/data/TCK/RAML10/Examples/test015/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test015/api-tck.json
@@ -109,7 +109,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "object should have not more then 1 properties",
+      "message": "object should have not more than 1 properties",
       "path": "api.raml",
       "line": 7,
       "column": 4,

--- a/src/raml1/test/data/TCK/RAML10/Examples/test017/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test017/api-tck.json
@@ -125,7 +125,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "object should have not less then 3 properties",
+      "message": "object should have not less than 3 properties",
       "path": "api.raml",
       "line": 12,
       "column": 6,

--- a/src/raml1/test/data/TCK/RAML10/Examples/test018/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test018/api-tck.json
@@ -79,7 +79,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "string length should be not less then 5",
+      "message": "string length should be not less than 5",
       "path": "api.raml",
       "line": 5,
       "column": 4,
@@ -99,7 +99,7 @@
     },
     {
       "code": 11,
-      "message": "string length should be not more then 3",
+      "message": "string length should be not more than 3",
       "path": "api.raml",
       "line": 8,
       "column": 4,

--- a/src/raml1/test/data/TCK/RAML10/Examples/test020/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test020/api-tck.json
@@ -106,7 +106,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "string length should be not less then 5",
+      "message": "string length should be not less than 5",
       "path": "api.raml",
       "line": 10,
       "column": 6,

--- a/src/raml1/test/data/TCK/RAML10/Examples/test022/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test022/api-tck.json
@@ -103,7 +103,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "value should be not less then 5",
+      "message": "value should be not less than 5",
       "path": "api.raml",
       "line": 6,
       "column": 4,
@@ -123,7 +123,7 @@
     },
     {
       "code": 11,
-      "message": "value should be not less then 5",
+      "message": "value should be not less than 5",
       "path": "api.raml",
       "line": 11,
       "column": 6,

--- a/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test002/oType02-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test002/oType02-tck.json
@@ -91,7 +91,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "object should have not less then 2 properties",
+      "message": "object should have not less than 2 properties",
       "path": "oType02.raml",
       "line": 9,
       "column": 4,

--- a/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test003/oType03-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/ObjectTypes/test003/oType03-tck.json
@@ -166,7 +166,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "object should have not more then 4 properties",
+      "message": "object should have not more than 4 properties",
       "path": "oType03.raml",
       "line": 13,
       "column": 4,

--- a/src/raml1/test/data/TCK/RAML10/Types/test019/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test019/api-tck.json
@@ -35,7 +35,7 @@
   "errors": [
     {
       "code": 11,
-      "message": "Restrictions conflict value should be not less then 10 and value should be not more then 1",
+      "message": "Restrictions conflict value should be not less than 10 and value should be not more than 1",
       "path": "api.raml",
       "line": 4,
       "column": 4,

--- a/src/raml1/test/parserTests.ts
+++ b/src/raml1/test/parserTests.ts
@@ -216,46 +216,46 @@ describe('Parser regression tests', function () {
         testErrors(util.data("parser/examples/ex15.raml"),["value should be one of:val1,val2,3"]);
     })
     it ("array facets" ,function(){
-        testErrors(util.data("parser/examples/ex16.raml"), ["array should have not less then 5 items", "array should have not more then 3 items", "items should be unique"]);
+        testErrors(util.data("parser/examples/ex16.raml"), ["array should have not less than 5 items", "array should have not more than 3 items", "items should be unique"]);
     })
     it ("array facets2" ,function(){
         testErrors(util.data("parser/examples/ex17.raml"));
     })
     it ("array facets3" ,function(){
-        testErrors(util.data("parser/examples/ex18.raml"), ["array should have not less then 5 items"]);
+        testErrors(util.data("parser/examples/ex18.raml"), ["array should have not less than 5 items"]);
     })
     it ("array facets4" ,function(){
-        testErrors(util.data("parser/examples/ex19.raml"),["array should have not less then 5 items"]);
+        testErrors(util.data("parser/examples/ex19.raml"),["array should have not less than 5 items"]);
     })
     it ("object facets1" ,function(){
-        testErrors(util.data("parser/examples/ex20.raml"), ["object should have not less then 2 properties"]);
+        testErrors(util.data("parser/examples/ex20.raml"), ["object should have not less than 2 properties"]);
     })
     it ("object facets2" ,function(){
-        testErrors(util.data("parser/examples/ex21.raml"), ["object should have not less then 2 properties"]);
+        testErrors(util.data("parser/examples/ex21.raml"), ["object should have not less than 2 properties"]);
     })
     it ("object facets3" ,function(){
-        testErrors(util.data("parser/examples/ex22.raml"), ["object should have not more then 1 properties"]);
+        testErrors(util.data("parser/examples/ex22.raml"), ["object should have not more than 1 properties"]);
     })
     it ("object facets4" ,function(){
         testErrors(util.data("parser/examples/ex23.raml"));
     })
     it ("object facets5" ,function(){
-        testErrors(util.data("parser/examples/ex24.raml"), ["object should have not less then 3 properties"]);
+        testErrors(util.data("parser/examples/ex24.raml"), ["object should have not less than 3 properties"]);
     })
     it ("string facets1" ,function(){
-        testErrors(util.data("parser/examples/ex25.raml"), ["string length should be not less then 5", "string length should be not more then 3"]);
+        testErrors(util.data("parser/examples/ex25.raml"), ["string length should be not less than 5", "string length should be not more than 3"]);
     })
     it ("string facets2" ,function(){
         testErrors(util.data("parser/examples/ex26.raml"));
     })
     it ("string facets3" ,function(){
-        testErrors(util.data("parser/examples/ex27.raml"), ["string length should be not less then 5"]);
+        testErrors(util.data("parser/examples/ex27.raml"), ["string length should be not less than 5"]);
     })
     it ("string facets4" ,function(){
         testErrors(util.data("parser/examples/ex28.raml"), ["string should match to \\.5"]);
     })
     it ("number facets1" ,function(){
-        testErrors(util.data("parser/examples/ex29.raml"),["value should be not less then \\w+", "value should be not less then \\w+"]);
+        testErrors(util.data("parser/examples/ex29.raml"),["value should be not less than \\w+", "value should be not less than \\w+"]);
     })
 
     it ("number facets2" ,function(){

--- a/src/raml1/test/parserTests2.ts
+++ b/src/raml1/test/parserTests2.ts
@@ -577,11 +577,11 @@ describe('Object types', function(){
     });
 
     it('Should parse minimum number of properties',function(){
-        testErrors(util.data('parser/objectTypes/oType02.raml'),["object should have not less then 2 properties"]);
+        testErrors(util.data('parser/objectTypes/oType02.raml'),["object should have not less than 2 properties"]);
     });
 
     it('Should parse maximum number of properties',function(){
-        testErrors(util.data('parser/objectTypes/oType03.raml'), ["object should have not more then 4 properties"]);
+        testErrors(util.data('parser/objectTypes/oType03.raml'), ["object should have not more than 4 properties"]);
     });
 
     it('Should parse property required option',function(){


### PR DESCRIPTION
fixing https://github.com/raml-org/raml-js-parser-2/issues/257