### PR TITLE
Allowing ~ as synonym for null in YAML

### DIFF
--- a/src/raml1/jsyaml/jsyaml2lowLevel.ts
+++ b/src/raml1/jsyaml/jsyaml2lowLevel.ts
@@ -2560,6 +2560,9 @@ export class ASTNode implements lowlevel.ILowLevelASTNode{
             return "";
         }
         if (this._node.kind==yaml.Kind.SCALAR){
+            if(this._node['value']==="~" && this._node['valueObject']===null){
+                return toString ? "null" : null;
+            }
             //TODO WHAT IS IT IS INCLUDE ACTUALLY
             if(!toString&&(""+this._node['valueObject']===this._node['value'])){
                 return this._node['valueObject'];

--- a/src/raml1/test/parserTests.ts
+++ b/src/raml1/test/parserTests.ts
@@ -1160,7 +1160,7 @@ describe('Property override tests',function(){
         testErrors(util.data("parser/custom/missedTitle.raml"),["property 'title' must be a string"]);
     });
     it ("expander not halted by this sample any more",function(){
-        testErrorsByNumber(util.data("parser/custom/expanderHalt.raml"),14);
+        testErrorsByNumber(util.data("parser/custom/expanderHalt.raml"),10);
     });
 });
 describe('Line mapper tests',function() {


### PR DESCRIPTION
Fixing https://github.com/raml-org/raml-js-parser-2/issues/234