### PR TITLE
For extentions fixing resolving libraries used by master API

### DIFF
--- a/src/raml1/ast.core/search.ts
+++ b/src/raml1/ast.core/search.ts
@@ -84,7 +84,7 @@ export function findDeclarations(h:hl.IHighLevelNode):hl.IHighLevelNode[]{
         if (x.definition().key()== universes.Universe10.UsesDeclaration) {
             var mm=x.attr("value");
             if (mm) {
-                var unit = h.root().lowLevel().unit().resolve(mm.value());
+                var unit = x.root().lowLevel().unit().resolve(mm.value());
                 if (unit != null) {
                     unit.highLevel().children().forEach(x=> {
                         if (x.isElement()) {

--- a/src/raml1/highLevelImpl.ts
+++ b/src/raml1/highLevelImpl.ts
@@ -44,7 +44,7 @@ export function qName(x:hl.IHighLevelNode,context:hl.IHighLevelNode):string{
                         if (x.definition().key() == universes.Universe10.UsesDeclaration) {
                             var mm = x.attr("value");
                             if (mm) {
-                                var unit = root.lowLevel().unit().resolve(mm.value());
+                                var unit = x.root().lowLevel().unit().resolve(mm.value());
                                 if (unit != null) {
                                     var key = x.attr("key");
                                     if (key) {

--- a/src/raml1/test/data/vfsTests/remoteExtend/local/extension-tck.json
+++ b/src/raml1/test/data/vfsTests/remoteExtend/local/extension-tck.json
@@ -1,0 +1,127 @@
+{
+  "ramlVersion": "RAML10",
+  "type": "Extension",
+  "specification": {
+    "uses": [
+      {
+        "key": "lib",
+        "value": "libs/lib.raml"
+      }
+    ],
+    "annotationTypes": [
+      {
+        "stringA": {
+          "name": "stringA",
+          "displayName": "stringA",
+          "type": [
+            "string"
+          ],
+          "repeat": false,
+          "required": true,
+          "__METADATA__": {
+            "primitiveValuesMeta": {
+              "displayName": {
+                "calculated": true
+              },
+              "repeat": {
+                "insertedAsDefault": true
+              },
+              "required": {
+                "insertedAsDefault": true
+              }
+            }
+          }
+        }
+      }
+    ],
+    "title": "New API",
+    "version": "v1",
+    "baseUri": "http://api.samplehost.com",
+    "protocols": [
+      "HTTP"
+    ],
+    "resources": [
+      {
+        "methods": [
+          {
+            "annotations": {
+              "stringA": {
+                "structuredValue": "string annotation value",
+                "name": "stringA"
+              }
+            },
+            "protocols": [
+              "HTTP"
+            ],
+            "method": "get",
+            "__METADATA__": {
+              "primitiveValuesMeta": {
+                "protocols": {
+                  "calculated": true
+                }
+              }
+            }
+          },
+          {
+            "body": {
+              "application/json": {
+                "name": "application/json",
+                "displayName": "application/json",
+                "type": [
+                  "lib.MyType"
+                ],
+                "repeat": false,
+                "required": true,
+                "__METADATA__": {
+                  "primitiveValuesMeta": {
+                    "displayName": {
+                      "calculated": true
+                    },
+                    "repeat": {
+                      "insertedAsDefault": true
+                    },
+                    "required": {
+                      "insertedAsDefault": true
+                    }
+                  }
+                }
+              }
+            },
+            "protocols": [
+              "HTTP"
+            ],
+            "method": "post",
+            "__METADATA__": {
+              "primitiveValuesMeta": {
+                "protocols": {
+                  "calculated": true
+                }
+              }
+            }
+          }
+        ],
+        "relativeUri": "/resource",
+        "displayName": "/resource",
+        "__METADATA__": {
+          "primitiveValuesMeta": {
+            "displayName": {
+              "calculated": true
+            }
+          }
+        },
+        "relativeUriPathSegments": [
+          "resource"
+        ]
+      }
+    ],
+    "extends": "https://WWW.__TESTDATA__.com/vfsTests/remoteExtend/web/api.raml",
+    "__METADATA__": {
+      "primitiveValuesMeta": {
+        "protocols": {
+          "calculated": true
+        }
+      }
+    }
+  },
+  "errors": []
+}

--- a/src/raml1/test/data/vfsTests/remoteExtend/local/extension.raml
+++ b/src/raml1/test/data/vfsTests/remoteExtend/local/extension.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0 Extension
+
+extends: https://WWW.__TESTDATA__.com/vfsTests/remoteExtend/web/api.raml
+
+annotationTypes:
+  stringA: string
+
+/resource:
+  get:
+    (stringA): string annotation value
+    body:

--- a/src/raml1/test/data/vfsTests/remoteExtend/web/api.raml
+++ b/src/raml1/test/data/vfsTests/remoteExtend/web/api.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0
+title: New API
+version: v1
+baseUri: http://api.samplehost.com
+
+uses:
+  lib: libs/lib.raml
+
+/resource:
+  post:
+    body:
+      application/json:
+        type: lib.MyType

--- a/src/raml1/test/data/vfsTests/remoteExtend/web/libs/lib.raml
+++ b/src/raml1/test/data/vfsTests/remoteExtend/web/libs/lib.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0 Library
+
+types:
+  MyType:
+    properties:
+      p1: string
+      p2: number

--- a/src/raml1/test/virtualFSTests.ts
+++ b/src/raml1/test/virtualFSTests.ts
@@ -52,6 +52,10 @@ describe('Virtual File System Tests', function() {
     it("JSON references test", function (done) {
         testAPI("./vfsTests/jsonRefsTest001/api.raml").should.be.fulfilled.and.notify(done);
     });
+
+    it("Uses test for extensions", function (done) {
+        testAPI("./vfsTests/remoteExtend/local/extension.raml").should.be.fulfilled.and.notify(done);
+    });
 });
 
 
@@ -72,10 +76,10 @@ export function testAPIHttpAsync(apiRelPath:string):any{
     var apiLocalPath = testUtil.data(apiRelPath);
     var apiDir = path.dirname(apiLocalPath);
 
-    var resolver = http2fs.getHttpResolver();
+    var httpResolver = http2fs.getHttpResolver();
     return index.loadApi(apiWebPath, {
         fsResolver: null,
-        httpResolver: resolver
+        httpResolver: httpResolver
     }).then(x=>{
         return inspect(x,apiDir);
     },y=>{
@@ -133,12 +137,14 @@ function testAPI(_apiPath:string):any{
             }            
         }
     };
-    
+
+    var httpResolver = http2fs.getHttpResolver();
     return vfsInstance.directory("/").then(x=>{
             return putEntry(0);
         }).then(x=> {
             return index.loadApi(apiRelPath, {
-                fsResolver: fsResolver
+                fsResolver: fsResolver,
+                httpResolver: httpResolver
             });
         }).then(x=>{
             return inspect(x,apiDir);


### PR DESCRIPTION
Fixing https://github.com/raml-org/raml-js-parser-2/issues/348

Some functional blocks of the parser, such as "search.ts" and "highLevelImpl.ts" were trying to resolve library path used by master api agains extension itself.

Adding a test for such situation.