### PR TITLE
Warnings instead of errors for unused URI parameters. Strict validation of default values in RAML 0.8.

### DIFF
--- a/src/raml1/ast.core/linter.ts
+++ b/src/raml1/ast.core/linter.ts
@@ -2969,7 +2969,14 @@ export class ExampleAndDefaultValueValidator implements PropertyValidator{
         return pObj;
     }
 
-    private isStrict(node) {
+    private isStrict(node:hl.IAttribute) {
+        if(universeHelpers.isDefaultValue(node.property())){
+            return true;
+        }
+        if(universeHelpers.isExampleProperty(node.property())
+            &&node.parent().definition().universe().version()=="RAML08"){
+            return true;
+        }
         var strictValidation:boolean = false;
         var strict = node.parent().attr("strict")
         if (strict) {
@@ -3101,7 +3108,7 @@ class UriParametersValidator implements NodeValidator {
                         }
                         var propNameReadable = pluralize.singular(changeCase.sentence(paramsPropName));
                         var message = changeCase.ucFirst(propNameReadable) + " unused";
-                        var issue = createIssue(hl.IssueCode.ILLEGAL_PROPERTY_VALUE, message, x, false);
+                        var issue = createIssue(hl.IssueCode.ILLEGAL_PROPERTY_VALUE, message, x, true);
                         v.accept(issue);
                     }
                 }

--- a/src/raml1/test/data/TCK/RAML08/MediaTypes/test002/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML08/MediaTypes/test002/api-tck.json
@@ -59,7 +59,8 @@
           "column": 43,
           "position": 176
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Api/test017/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Api/test017/api-tck.json
@@ -82,7 +82,8 @@
           "column": 3,
           "position": 75
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Examples/test006/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test006/api-tck.json
@@ -113,7 +113,8 @@
           "column": 7,
           "position": 135
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Examples/test028/api-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Examples/test028/api-tck.json
@@ -273,7 +273,8 @@
           "column": 20,
           "position": 524
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Fragments/test006/libs/lib.raml
+++ b/src/raml1/test/data/TCK/RAML10/Fragments/test006/libs/lib.raml
@@ -1,0 +1,8 @@
+#%RAML1.0 Library
+
+annotationTypes:
+  StringAnnotation:
+  ObjectAnnotation:
+    properties:
+      p1: string
+      p2: number

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test003/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test003/apiInvalid-tck.json
@@ -487,7 +487,8 @@
           "column": 9,
           "position": 944
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test004/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test004/apiInvalid-tck.json
@@ -487,7 +487,8 @@
           "column": 9,
           "position": 944
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test005/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test005/apiInvalid-tck.json
@@ -487,7 +487,8 @@
           "column": 9,
           "position": 944
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test006/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test006/apiInvalid-tck.json
@@ -487,7 +487,8 @@
           "column": 9,
           "position": 944
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test007/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test007/apiInvalid-tck.json
@@ -485,7 +485,8 @@
           "column": 24,
           "position": 1006
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test008/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test008/apiInvalid-tck.json
@@ -485,7 +485,8 @@
           "column": 27,
           "position": 1004
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test009/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test009/apiInvalid-tck.json
@@ -485,7 +485,8 @@
           "column": 35,
           "position": 1004
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test010/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test010/apiInvalid-tck.json
@@ -483,7 +483,8 @@
           "column": 27,
           "position": 1002
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/ResourceTypes/test011/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/ResourceTypes/test011/apiInvalid-tck.json
@@ -442,7 +442,8 @@
           "column": 35,
           "position": 854
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Resources/test002/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test002/apiInvalid-tck.json
@@ -149,7 +149,8 @@
           "column": 8,
           "position": 96
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Resources/test007/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test007/apiInvalid-tck.json
@@ -436,7 +436,8 @@
           "column": 29,
           "position": 838
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Resources/test008/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test008/apiInvalid-tck.json
@@ -436,7 +436,8 @@
           "column": 37,
           "position": 878
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Resources/test009/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test009/apiInvalid-tck.json
@@ -436,7 +436,8 @@
           "column": 29,
           "position": 826
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Resources/test010/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test010/apiInvalid-tck.json
@@ -436,7 +436,8 @@
           "column": 37,
           "position": 878
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Resources/test011/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test011/apiInvalid-tck.json
@@ -447,7 +447,8 @@
           "column": 17,
           "position": 855
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Resources/test012/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test012/apiInvalid-tck.json
@@ -447,7 +447,8 @@
           "column": 17,
           "position": 858
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Resources/test013/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test013/apiInvalid-tck.json
@@ -447,7 +447,8 @@
           "column": 17,
           "position": 866
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Resources/test014/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test014/apiInvalid-tck.json
@@ -449,7 +449,8 @@
           "column": 17,
           "position": 910
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Resources/test015/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Resources/test015/apiInvalid-tck.json
@@ -451,7 +451,8 @@
           "column": 9,
           "position": 786
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Traits/test001/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Traits/test001/apiInvalid-tck.json
@@ -854,7 +854,8 @@
           "column": 25,
           "position": 1054
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Traits/test002/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Traits/test002/apiInvalid-tck.json
@@ -854,7 +854,8 @@
           "column": 25,
           "position": 1054
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Traits/test002/apiValid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Traits/test002/apiValid-tck.json
@@ -854,7 +854,8 @@
           "column": 25,
           "position": 1054
         }
-      ]
+      ],
+      "isWarning": true
     }
   ]
 }

--- a/src/raml1/test/data/TCK/RAML10/Types/test002/apiInvalid-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test002/apiInvalid-tck.json
@@ -165,7 +165,8 @@
           "column": 11,
           "position": 223
         }
-      ]
+      ],
+      "isWarning": true
     },
     {
       "code": 11,

--- a/src/raml1/test/data/TCK/RAML10/Types/test030/lib-tck.json
+++ b/src/raml1/test/data/TCK/RAML10/Types/test030/lib-tck.json
@@ -1,0 +1,33 @@
+{
+  "ramlVersion": "RAML10",
+  "type": "Library",
+  "specification": {
+    "types": [
+      {
+        "Foo": {
+          "name": "Foo",
+          "displayName": "Foo",
+          "type": [
+            "null"
+          ],
+          "repeat": false,
+          "required": true,
+          "__METADATA__": {
+            "primitiveValuesMeta": {
+              "displayName": {
+                "calculated": true
+              },
+              "repeat": {
+                "insertedAsDefault": true
+              },
+              "required": {
+                "insertedAsDefault": true
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  "errors": []
+}

--- a/src/raml1/test/data/TCK/RAML10/Types/test030/lib.raml
+++ b/src/raml1/test/data/TCK/RAML10/Types/test030/lib.raml
@@ -1,0 +1,4 @@
+#%RAML 1.0 Library
+
+types:
+  Foo: ~

--- a/src/raml1/test/example-ramls/platform2/api.raml
+++ b/src/raml1/test/example-ramls/platform2/api.raml
@@ -1010,7 +1010,7 @@ securedBy: [ oauth_2_0 ]
             body:
               example: |
                 {
-                  id: "36d6f025-cdd9-4c06-9320-7dccb1f13db2"
+                  "id": "36d6f025-cdd9-4c06-9320-7dccb1f13db2"
                 }
             responses:
               201:

--- a/src/raml1/tools/universeHelpers.ts
+++ b/src/raml1/tools/universeHelpers.ts
@@ -185,6 +185,11 @@ export function isBodyProperty(p:hl.IProperty) : boolean {
     p.nameId() === universe.Universe08.Response.properties.body.name
 }
 
+export function isDefaultValue(p:hl.IProperty) : boolean {
+    return p.nameId() === universe.Universe10.TypeDeclaration.properties.default.name ||
+        p.nameId() === universe.Universe08.Parameter.properties.default.name;
+}
+
 export function isSchemaProperty(p:hl.IProperty) : boolean {
     return p.nameId() === universe.Universe08.BodyLike.properties.schema.name ||
     p.nameId() === universe.Universe08.XMLBody.properties.schema.name ||

--- a/src/util/TCKDumper.ts
+++ b/src/util/TCKDumper.ts
@@ -219,7 +219,7 @@ export class TCKDumper{
 
     private dumpErrors(errors:core.RamlParserError[]) {
         return errors.map(x=> {
-            return {
+            var eObj:any = {
                 "code": x.code, //TCK error code
                 "message": x.message,
                 "path": x.path,
@@ -227,7 +227,11 @@ export class TCKDumper{
                 "column": x.column,
                 "position": x.start,
                 "range": x.range
+            };
+            if(x.isWarning===true){
+                eObj.isWarning = true;
             }
+            return eObj;
         }).sort((x, y)=> {
             if (x.path != y.path) {
                 return x.path.localeCompare(y.path);


### PR DESCRIPTION
Fixing issues.
https://github.com/raml-org/raml-js-parser-2/issues/309
https://github.com/raml-org/raml-js-parser-2/issues/350

* The parser is made to issue warnings rather then errors for unused URI parameters.
* The parser is made to issue errorss rather then warnings for unused miscorrespondences between parameter types and their default value types in RAML 0.8.