### PR TITLE
Fix unexpected output "null"

### DIFF
--- a/src/raml1/jsyaml/jsyaml2lowLevel.ts
+++ b/src/raml1/jsyaml/jsyaml2lowLevel.ts
@@ -2177,7 +2177,7 @@ export class ASTNode implements lowlevel.ILowLevelASTNode{
         private cacheChildren:boolean = false,
         private _includesContents = false) {
         if (_node==null){
-            console.log("null")
+            this._errors.push(new Error("_node is null"))
         }
     }
     actual(): any{

--- a/src/raml1/jsyaml/jsyaml2lowLevel.ts
+++ b/src/raml1/jsyaml/jsyaml2lowLevel.ts
@@ -2176,8 +2176,8 @@ export class ASTNode implements lowlevel.ILowLevelASTNode{
         private _include: ASTNode,
         private cacheChildren:boolean = false,
         private _includesContents = false) {
-        if (_node==null){
-            this._errors.push(new Error("_node is null"))
+        if (_node == null) {
+            // console.log("null")
         }
     }
     actual(): any{


### PR DESCRIPTION
When I use raml2html, output is:

```
null
<!DOCTYPE HTML>
<html>
...
</html>
```

The first line "null" is unexpected!

I think no reason to use `console.log` in a library.
