### PR TITLE
External type integration with master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ npm-debug.log
 
 .project
 .settings
+.idea/*
 
 /browserVersion
 /browser_version_npm

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "json-loader": "^0.5.1",
     "dev-env-installer": "0.0.5",
     "rimraf": "*",
-    "gulp-istanbul" : "*"
+    "gulp-istanbul": "*"
   },
   "browser": {
     "fs": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -277,4 +277,3 @@ export type IParseResult=hl.IParseResult;
 if(typeof Promise === 'undefined' && typeof window !== 'undefined') {
     (<any>window).Promise = PromiseConstructor;
 }
-

--- a/src/raml1/ast.core/linter.ts
+++ b/src/raml1/ast.core/linter.ts
@@ -398,6 +398,30 @@ function validateTopLevelNodeSkippingChildren(node : hl.IParseResult,v:hl.Valida
 }
 
 /**
+ * According to RAML spec:
+ *   "When an object type does not contain the "properties" facet, the object is assumed
+ *   to be unconstrained and therefore capable of containing any properties of any type."
+ * @param node
+ */
+function hasPlainObjectInHierarchy(node: hl.IParseResult) {
+    while(node !== null && node.property() === null) {
+        node = node.parent();
+    }
+
+    if (node === null)
+        return false;
+
+    const type = node.property().range();
+
+    if (type.properties() !== null && type.properties().length > 0) {
+        return false;
+    }
+
+    const superTypes = type.allSuperTypes();
+    return !superTypes.some(st => st.nameId() !== 'object' && st.nameId() !== 'any');
+}
+
+/**
  * Performs basic validation of a node on a single level, without proceeding to the node high-level children validation.
  * @param node
  * @param v
@@ -489,7 +513,7 @@ export function validateBasicFlat(node:hlimpl.BasicASTNode,v:hl.ValidationAccept
         }
         else {
             var issue = restrictUnknownNodeError(node);
-            if(!issue){
+            if(!issue && !hasPlainObjectInHierarchy(node)) {
                 issue = createIssue1(messageRegistry.UNKNOWN_NODE, {name : node.name()}, node);
             }
             v.accept(issue);
@@ -2316,7 +2340,10 @@ class RAMLVersionAndFragmentValidator implements NodeValidator{
 
     validate(node:hl.IHighLevelNode,v:hl.ValidationAcceptor){
         var u=(<hlimpl.ASTNodeImpl>node).universe();
-        var tv=u.getTypedVersion();
+        let tv;
+        if (u && u.getTypedVersion) {
+            tv=u.getTypedVersion();
+        }
         if (tv){
             if (tv !== "0.8" && tv !== "1.0") {
                 var i = createIssue1(messageRegistry.UNKNOWN_RAML_VERSION, {}, node)

--- a/src/raml1/ast.core/typeBuilder.ts
+++ b/src/raml1/ast.core/typeBuilder.ts
@@ -358,6 +358,13 @@ export function convertType(root:hl.IHighLevelNode,t:ramlTypes.IParsedType):hl.I
                 }
             }
 
+            if (!propertySource) {
+                var at = node.attrs().filter(y => y.name() == x);
+                if (at && at.length > 0) {
+                    propertySource = at[0];
+                }
+            }
+
             var v = new defs.UserDefinedProp(x, propertySource);
             v.unmerge();
             return v;

--- a/src/raml1/highLevelImpl.ts
+++ b/src/raml1/highLevelImpl.ts
@@ -263,6 +263,9 @@ export class BasicASTNode implements hl.IParseResult {
 
 
     name(){
+        if (!this.lowLevel() || !this.lowLevel().key) {
+            return "";
+        }
         var c=this.lowLevel().key();
         if (!c){
             return "";
@@ -2139,7 +2142,7 @@ var getDefinitionSystemType = function (contents:string,ast:ll.ILowLevelASTNode)
 };
 
 export function ramlFirstLine(content:string):RegExpMatchArray{
-    return content.match(/^\s*#%RAML\s+(\d\.\d)\s*(\w*)\s*$/m);
+    return content.match(/^\s*#%RAML\s+(\d\.\d)[ \t]*?(\S.*?|)\s*?$/m);
 }
 
 export function getFragmentDefenitionName(highLevelNode: hl.IHighLevelNode): string {
@@ -2156,14 +2159,36 @@ export function fromUnit(l: ll.ICompilationUnit): hl.IParseResult {
     if (l == null)
         return null;
 
+    let apiType;
+    let localUniverse;
     var contents = l.contents();
-    var ast = l.ast();
-    var __ret = getDefinitionSystemType(contents, ast);
-    var ptype = __ret.ptype;
-    var localUniverse = __ret.localUniverse;
-    var apiType = localUniverse.type(ptype)
+    var rfl = ramlFirstLine(contents);
+    if (!rfl && utils.getDefaultHeader()) {
+        rfl = ramlFirstLine(utils.getDefaultHeader());
+    }
+    if (rfl && rfl.length && rfl.length > 2 && rfl[2] && typeof rfl[2] === 'string' && rfl[2].indexOf("ExternalType") == 0) {
+        const extTypeSpec = rfl[2].split(" ");
+        if (extTypeSpec.length > 2) {
+            const extTypeName = extTypeSpec[1];
+            const extTypePath = extTypeSpec[2];
+            const project = l.project();
+            const parentUnit = project.unit(extTypePath);
+            const parentApi = <hl.IHighLevelNode>fromUnit(parentUnit);
+            const parsedType = parentApi.types().getType(extTypeName);
+            apiType = rTypes.toNominal(parsedType, x=>null);
+        }
+    }
 
-    if (!apiType) apiType = localUniverse.type("Api");
+    var ast = l.ast();
+    if (apiType) {
+        localUniverse = apiType.universe();
+    } else {
+        var __ret = getDefinitionSystemType(contents, ast);
+        localUniverse = __ret.localUniverse;
+        var ptype = __ret.ptype;
+        apiType = localUniverse.type(ptype);
+        if (!apiType) apiType = localUniverse.type("Api");
+    }
 
     var api = new ASTNodeImpl(ast, null, <any>apiType, null);
     api.setUniverse(localUniverse);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,23 @@ import linter=require("./raml1/ast.core/linter")
 import builder=require("./raml1/ast.core/builder")
 import universes = require("./raml1/tools/universe")
 
+let defaultHeaderValue: string = null;
+
+/**
+ * This function can be used to set default header line that will be
+ * used by a parser when no correct RAML header was found in a file.
+ *
+ * For example:
+ *   #RAML 1.0 ExternalType SomeTypeName path/to/scheme.raml
+ */
+export function setDefaultHeader(header: string) {
+    defaultHeaderValue = header;
+}
+
+export function getDefaultHeader() {
+    return defaultHeaderValue;
+}
+
 export function hasAsyncRequests(){
     return rs.hasAsyncRequests();
 }


### PR DESCRIPTION
This pull request adds support for a couple of important missing features and fixes a couple of existing bugs.

1. Major feature: `#%RAML 1.0 ExternalType <TypeName> <raml file>` header.
This header allows a parser to parse an existing .raml file in the context of the raml type named `<TypeName>` declared in `<raml file>`.

2. Important fix: parser now correctly supports types with union supertypes and additional properties, for example:
```
types:
  [...]
  SampleType:
    type: [A | B | C]
    properties:
      samplePropD: string
      samplePropE: int
```
Before the suggested patch, samplePropD and samplePropE would not be recognized by the parser if used in the context of a SampleType. Now this case is supported correctly.

3. RAML spec requires for a type that has an object as its supertype and no properties declared to accept any valid object as its value. This feature is not supported in the current raml parser, so its implementation is provided in the patch.

4. an utility method was added to allow parser to parse RAML types with no valid `#%RAML` header using some default preset header value.