### PR TITLE
Dep. replace unmaintained `marked` with `8fold-marked`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "extractTypings": "node ./dist/devUtil/extractTypings.js"
   },
   "dependencies": {
+    "8fold-marked": "0.3.8",
     "base64url": "2.0.0",
     "change-case": "3.0.1",
     "concat-stream": "1.6.0",
@@ -34,7 +35,6 @@
     "loophole": "1.1.0",
     "lrucache": "1.0.3",
     "promise-polyfill": "6.0.2",
-    "marked": "0.3.6",
     "media-typer": "0.3.0",
     "mkdirp": "0.5.1",
     "pluralize": "7.0.0",

--- a/src/parser/devTools/docGen.ts
+++ b/src/parser/devTools/docGen.ts
@@ -1,7 +1,7 @@
 import def=require("raml-definition-system")
 import _=require("underscore")
 import fs=require("fs")
-import marked = require('marked');
+import marked = require('8fold-marked');
 import services=def
 
 export function def2Doc(t:def.NodeClass,refPrefix:string=''):string{
@@ -567,4 +567,3 @@ export function table(d:ITableDataProvider<any>,isInRefSection:boolean=false,ref
     result.push("</table>")
     return result.join("\n")
 }
-


### PR DESCRIPTION
`marked` seems to have been abandoned.  There's a friendly fork here: https://github.com/8fold/marked

There's a patch there the fix a regex issue described here: https://github.com/chjj/marked/issues/937 and here: https://snyk.io/vuln/npm:marked:20170907

tracking: https://github.com/digitalbazaar/bedrock-docs/issues/6