### PR TITLE
[CHHYBRID-4320] Update z-schema version due to validator ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raml-1-parser",
-  "version": "1.1.45",
+  "version": "1.1.46",
   "main": "dist/index.js",
   "scripts": {
     "compile": "rimraf dist && tsc",
@@ -48,7 +48,7 @@
     "xmldom": "0.1.27",
     "xmlhttprequest": "1.8.0",
     "yaml-ast-parser": "0.0.40",
-    "z-schema": "3.18.4"
+    "z-schema": "~3.21.0"
   },
   "typings": "./dist/index.d.ts",
   "repository": {


### PR DESCRIPTION
Updating z-schema version from v3.18.4 -> v~3.21.0 so it changes it's dependency on validator(v8.0.0 -> v10.0.0). [This fixes a ReDoS vulnerability](https://github.com/chriso/validator.js/commit/19508354cde4e08c75b377321a3d5f910dddee4e#diff-2133470579720aaf8cdd154075553315R14). 