### PR TITLE
Updated z-schema to v4.0.1 (adds support for circular references)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6732,15 +6732,15 @@
       }
     },
     "z-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.25.1.tgz",
-      "integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.0.1.tgz",
+      "integrity": "sha512-eYi6JZ3iq01zIpDLXbz9oQrstXVQ6dtR0u6nXGsCG+dDDtcDi7p2r2zCrih5n6brb35b+ad7H/mSimV8KckxCQ==",
       "requires": {
         "commander": "^2.7.1",
         "core-js": "^2.5.7",
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^10.0.0"
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^10.11.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "xmldom": "0.1.27",
     "xmlhttprequest": "1.8.0",
     "yaml-ast-parser": "0.0.43",
-    "z-schema": "3.25.1"
+    "z-schema": "4.0.1"
   },
   "typings": "./dist/index.d.ts",
   "repository": {


### PR DESCRIPTION
Fixes #809 - circular references in JSON schemas are now possible.
Prerequisite was to fix https://github.com/zaggino/z-schema/issues/19, we made a PR to z-schema and then prepared this. 

@KonstantinSviridov @ddenisenko @postatum, we are using this library internally in our company and we need to use circular schemas really urgently, so we would appreciate if this PR could be merged and released ASAP!
